### PR TITLE
🛠️ refactor: JoinPeriod 폴더 구조 재정리

### DIFF
--- a/src/main/java/com/gdg/homepage/landing/admin/domain/JoinPeriod.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/domain/JoinPeriod.java
@@ -1,4 +1,4 @@
-package com.gdg.homepage.landing.register.domain;
+package com.gdg.homepage.landing.admin.domain;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/gdg/homepage/landing/admin/repository/JoinPeriodRepository.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/repository/JoinPeriodRepository.java
@@ -1,6 +1,6 @@
-package com.gdg.homepage.landing.register.repository;
+package com.gdg.homepage.landing.admin.repository;
 
-import com.gdg.homepage.landing.register.domain.JoinPeriod;
+import com.gdg.homepage.landing.admin.domain.JoinPeriod;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JoinPeriodRepository extends JpaRepository<JoinPeriod, Long> {

--- a/src/main/java/com/gdg/homepage/landing/register/domain/Register.java
+++ b/src/main/java/com/gdg/homepage/landing/register/domain/Register.java
@@ -1,6 +1,7 @@
 package com.gdg.homepage.landing.register.domain;
 
 import com.gdg.homepage.common.domain.BaseTimeEntity;
+import com.gdg.homepage.landing.admin.domain.JoinPeriod;
 import com.gdg.homepage.landing.member.domain.Member;
 import jakarta.persistence.*;
 


### PR DESCRIPTION
## PR 제목  
JoinPeriod 폴더 구조 변경 및 이동  

## 세부내용  
- 기존 `JoinPeriod` 폴더가 `register` 경로에 위치  
- `admin` 폴더로 이동하여 구조 정리  
- 관리 기능과의 연관성을 고려한 폴더 구조 개선