### PR TITLE
✨ feat : 신청서와 회원가입 동시 처리 구현 , 시큐리티 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,15 +24,28 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-//    implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // 기본
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // DB 관련
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    annotationProcessor 'org.projectlombok:lombok'
+
+    // 시큐리티
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+
+    // Test 관련
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/gdg/homepage/common/config/DataInitializer.java
+++ b/src/main/java/com/gdg/homepage/common/config/DataInitializer.java
@@ -1,0 +1,75 @@
+package com.gdg.homepage.common.config;
+
+import com.gdg.homepage.landing.admin.domain.JoinPeriod;
+import com.gdg.homepage.landing.admin.repository.JoinPeriodRepository;
+import com.gdg.homepage.landing.member.domain.Member;
+import com.gdg.homepage.landing.member.domain.MemberRole;
+import com.gdg.homepage.landing.member.repository.MemberRepository;
+import com.gdg.homepage.landing.register.domain.Register;
+import com.gdg.homepage.landing.register.domain.RegisterSnippet;
+import com.gdg.homepage.landing.register.domain.Role;
+import com.gdg.homepage.landing.register.domain.TechField;
+import com.gdg.homepage.landing.register.domain.TechStack;
+import com.gdg.homepage.landing.register.repository.RegisterRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.time.LocalDateTime;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class DataInitializer {
+
+    private final MemberRepository memberRepository;
+    private final RegisterRepository registerRepository;
+    private final JoinPeriodRepository joinPeriodRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    @Value("${admin.email}")
+    private String adminEmail;
+
+    @Value("${admin.password}")
+    private String adminPassword;
+
+    @Bean
+    public CommandLineRunner initAdmin() {
+        return args -> {
+            // JoinPeriod 생성
+            JoinPeriod forAdmin = JoinPeriod.builder()
+                    .title("어드민 생성")
+                    .startDate(LocalDateTime.of(2020, 1, 1, 0, 0))
+                    .endDate(LocalDateTime.of(2020, 12, 31, 23, 59))
+                    .maxMember(1)
+                    .build();
+
+            joinPeriodRepository.save(forAdmin);
+
+            // Register 생성
+            RegisterSnippet snippet = RegisterSnippet.of(5, "가천어드민", "가천", TechField.OTHER, TechStack.OTHER);
+            Register register = Register.of(forAdmin, snippet, Role.ORGANIZER);
+            register.approve();
+
+            registerRepository.save(register);
+
+            // Member 생성
+            Member member = Member.builder()
+                    .name("어드민")
+                    .email(adminEmail)
+                    .phoneNumber("010-0000-0000")
+                    .password(bCryptPasswordEncoder.encode(adminPassword))
+                    .role(MemberRole.ORGANIZER)
+                    .build();
+            member.setRegister(register);
+
+            memberRepository.save(member);
+
+            log.info("✅ 어드민 계정이 생성되었습니다. email: {}", adminEmail);
+        };
+    }
+}

--- a/src/main/java/com/gdg/homepage/common/config/SecurityConfig.java
+++ b/src/main/java/com/gdg/homepage/common/config/SecurityConfig.java
@@ -1,14 +1,13 @@
 package com.gdg.homepage.common.config;
 
-import com.gdg.homepage.common.security.jwt.filter.LoginFilter;
 import com.gdg.homepage.common.security.jwt.filter.TokenAuthenticationFilter;
 import com.gdg.homepage.common.security.jwt.provider.JwtTokenProvider;
+import com.gdg.homepage.landing.member.domain.MemberRole;
 import com.gdg.homepage.landing.member.service.MemberDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -25,43 +24,34 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationManagerBuilder authenticationManager) throws Exception {
-
-
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf((auth) -> auth.disable());
-
-        http
-                .formLogin((auth) -> auth.disable());
-
-        http
-                .httpBasic((auth) -> auth.disable());
-
-        http
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll() // 모든 요청 허용
-                );
-        http
-                .addFilterBefore(new TokenAuthenticationFilter(jwtTokenProvider), LoginFilter.class);
-
-        http
-                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
-
-        http
-                .sessionManagement((session) -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+                        .requestMatchers("/", "/api/v1/member/register", "/api/v1/member/login").permitAll()
+                        .requestMatchers("/api/v1/member/myPage").hasAnyAuthority(
+                                MemberRole.MEMBER.getRole(), MemberRole.NON_MEMBER.getRole(),
+                                MemberRole.TEAM_MEMBER.getRole(), MemberRole.ORGANIZER.getRole())
+                        .requestMatchers("/api/v1/registers/").permitAll()
+                        .requestMatchers("/admin/**").hasAnyAuthority(
+                                MemberRole.TEAM_MEMBER.getRole(), MemberRole.ORGANIZER.getRole())
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(new TokenAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         return http.build();
     }
+
     @Bean
-    public BCryptPasswordEncoder bCryptPasswordEncoder(){
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
-    //AuthenticationManager Bean 등록
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
-
         return configuration.getAuthenticationManager();
     }
 }

--- a/src/main/java/com/gdg/homepage/common/config/SecurityConfig.java
+++ b/src/main/java/com/gdg/homepage/common/config/SecurityConfig.java
@@ -3,7 +3,6 @@ package com.gdg.homepage.common.config;
 import com.gdg.homepage.common.security.jwt.filter.TokenAuthenticationFilter;
 import com.gdg.homepage.common.security.jwt.provider.JwtTokenProvider;
 import com.gdg.homepage.landing.member.domain.MemberRole;
-import com.gdg.homepage.landing.member.service.MemberDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,8 +18,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final MemberDetailsService memberDetailsService;
-    private final AuthenticationConfiguration authenticationConfiguration;
     private final JwtTokenProvider jwtTokenProvider;
 
     @Bean

--- a/src/main/java/com/gdg/homepage/common/config/SecurityConfig.java
+++ b/src/main/java/com/gdg/homepage/common/config/SecurityConfig.java
@@ -1,4 +1,67 @@
 package com.gdg.homepage.common.config;
 
+import com.gdg.homepage.common.security.jwt.filter.LoginFilter;
+import com.gdg.homepage.common.security.jwt.filter.TokenAuthenticationFilter;
+import com.gdg.homepage.common.security.jwt.provider.JwtTokenProvider;
+import com.gdg.homepage.landing.member.service.MemberDetailsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final MemberDetailsService memberDetailsService;
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationManagerBuilder authenticationManager) throws Exception {
+
+
+        http
+                .csrf((auth) -> auth.disable());
+
+        http
+                .formLogin((auth) -> auth.disable());
+
+        http
+                .httpBasic((auth) -> auth.disable());
+
+        http
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll() // 모든 요청 허용
+                );
+        http
+                .addFilterBefore(new TokenAuthenticationFilter(jwtTokenProvider), LoginFilter.class);
+
+        http
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+
+        http
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+
+    //AuthenticationManager Bean 등록
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+
+        return configuration.getAuthenticationManager();
+    }
 }

--- a/src/main/java/com/gdg/homepage/common/config/SecurityConfig.java
+++ b/src/main/java/com/gdg/homepage/common/config/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
                 .httpBasic(basic -> basic.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/", "/api/v1/member/register", "/api/v1/member/login").permitAll()
-                        .requestMatchers("/api/v1/member/myPage").hasAnyAuthority(
+                        .requestMatchers("/api/v1/member/**").hasAnyAuthority(
                                 MemberRole.MEMBER.getRole(), MemberRole.NON_MEMBER.getRole(),
                                 MemberRole.TEAM_MEMBER.getRole(), MemberRole.ORGANIZER.getRole())
                         .requestMatchers("/api/v1/registers/").permitAll()

--- a/src/main/java/com/gdg/homepage/common/response/page/PageRequest.java
+++ b/src/main/java/com/gdg/homepage/common/response/page/PageRequest.java
@@ -1,0 +1,21 @@
+package com.gdg.homepage.common.response.page;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
+
+@Data
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+@Slf4j
+public class PageRequest {
+    @Builder.Default
+    private int page = 1;
+
+    @Builder.Default
+    private int size = 10;
+}

--- a/src/main/java/com/gdg/homepage/common/response/page/PageResponse.java
+++ b/src/main/java/com/gdg/homepage/common/response/page/PageResponse.java
@@ -1,0 +1,58 @@
+package com.gdg.homepage.common.response.page;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+
+@Data
+public class PageResponse<E> {
+
+    private List<E> result;
+
+    private List<Integer> pageNumList;
+
+    private PageRequest pageRequest;
+
+    private boolean prev, next;
+
+    private int totalCount, prevPage, nextPage, totalPage, current;
+
+    @Builder(builderMethodName = "withAll")
+    public PageResponse(List<E> result, PageRequest pageRequest, long total) {
+
+        this.result = result;
+        this.pageRequest = pageRequest;
+        this.totalCount = (int)total;
+
+        int end =   (int)(Math.ceil( pageRequest.getPage() / 10.0 )) *  10;
+
+        int start = end - 9;
+
+        int last =  (int)(Math.ceil((totalCount/(double) pageRequest.getSize())));
+
+        end =  end > last ? last: end;
+
+        this.prev = start > 1;
+        this.next =  totalCount > end * pageRequest.getSize();
+
+        this.pageNumList = IntStream.rangeClosed(start,end).boxed().collect(Collectors.toList());
+
+        if(prev) {
+            this.prevPage = start -1;
+        }
+
+        if(next) {
+            this.nextPage = end + 1;
+        }
+
+        this.totalPage = this.pageNumList.size();
+
+        this.current = pageRequest.getPage();
+
+    }
+}
+

--- a/src/main/java/com/gdg/homepage/common/security/jwt/filter/LoginFilter.java
+++ b/src/main/java/com/gdg/homepage/common/security/jwt/filter/LoginFilter.java
@@ -1,0 +1,49 @@
+package com.gdg.homepage.common.security.jwt.filter;
+
+import com.gdg.homepage.common.security.jwt.provider.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+
+        //클라이언트 요청에서 username, password 추출
+        String username = obtainUsername(request);
+        String password = obtainPassword(request);
+
+        //스프링 시큐리티에서 username과 password를 검증하기 위해서는 token에 담아야 함
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password, null);
+
+        //token에 담은 검증을 위한 AuthenticationManager로 전달
+        return authenticationManager.authenticate(authToken);
+    }
+
+    //로그인 성공시 실행하는 메소드 (여기서 JWT를 발급하면 됨)
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
+
+        String token = jwtTokenProvider.generateToken(authentication, 60*60*10L);
+
+        response.addHeader("Authorization", "Bearer " + token);
+    }
+
+    //로그인 실패시 실행하는 메소드
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
+        response.setStatus(401);
+    }
+}
+

--- a/src/main/java/com/gdg/homepage/common/security/jwt/filter/LoginFilter.java
+++ b/src/main/java/com/gdg/homepage/common/security/jwt/filter/LoginFilter.java
@@ -1,49 +1,50 @@
-package com.gdg.homepage.common.security.jwt.filter;
-
-import com.gdg.homepage.common.security.jwt.provider.JwtTokenProvider;
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-
-@RequiredArgsConstructor
-public class LoginFilter extends UsernamePasswordAuthenticationFilter {
-
-    private final AuthenticationManager authenticationManager;
-    private final JwtTokenProvider jwtTokenProvider;
-
-    @Override
-    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
-
-        //클라이언트 요청에서 username, password 추출
-        String username = obtainUsername(request);
-        String password = obtainPassword(request);
-
-        //스프링 시큐리티에서 username과 password를 검증하기 위해서는 token에 담아야 함
-        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password, null);
-
-        //token에 담은 검증을 위한 AuthenticationManager로 전달
-        return authenticationManager.authenticate(authToken);
-    }
-
-    //로그인 성공시 실행하는 메소드 (여기서 JWT를 발급하면 됨)
-    @Override
-    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
-
-        String token = jwtTokenProvider.generateToken(authentication, 60*60*10L);
-
-        response.addHeader("Authorization", "Bearer " + token);
-    }
-
-    //로그인 실패시 실행하는 메소드
-    @Override
-    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
-        response.setStatus(401);
-    }
-}
-
+//package com.gdg.homepage.common.security.jwt.filter;
+//
+//import com.gdg.homepage.common.security.jwt.provider.JwtTokenProvider;
+//import jakarta.servlet.FilterChain;
+//import jakarta.servlet.http.HttpServletRequest;
+//import jakarta.servlet.http.HttpServletResponse;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.security.authentication.AuthenticationManager;
+//import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+//import org.springframework.security.core.Authentication;
+//import org.springframework.security.core.AuthenticationException;
+//import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+//
+//@RequiredArgsConstructor
+//public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+//
+//    private final AuthenticationManager authenticationManager;
+//    private final JwtTokenProvider jwtTokenProvider;
+//
+//    @Override
+//    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+//
+//        //클라이언트 요청에서 username, password 추출
+//        String username = obtainUsername(request);
+//        String password = obtainPassword(request);
+//
+//        //스프링 시큐리티에서 username과 password를 검증하기 위해서는 token에 담아야 함
+//        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password, null);
+//
+//        //token에 담은 검증을 위한 AuthenticationManager로 전달
+//        return authenticationManager.authenticate(authToken);
+//    }
+//
+//    //로그인 성공시 실행하는 메소드 (여기서 JWT를 발급하면 됨)
+//    @Override
+//    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
+//
+//        String token = jwtTokenProvider.generateAccessToken(authentication);
+//
+//        response.addHeader("Authorization", "Bearer " + token);
+//    }
+//
+//    //로그인 실패시 실행하는 메소드
+//    @Override
+//    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
+//        response.setStatus(401);
+//
+//    }
+//}
+//

--- a/src/main/java/com/gdg/homepage/common/security/jwt/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/gdg/homepage/common/security/jwt/filter/TokenAuthenticationFilter.java
@@ -1,0 +1,72 @@
+package com.gdg.homepage.common.security.jwt.filter;
+
+import com.gdg.homepage.common.security.jwt.provider.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TokenAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        // Access Token 추출
+        String accessToken = resolveToken(request);
+
+        // Access Token 검증 및 인증 설정
+        if (accessToken != null && tokenProvider.validateToken(accessToken)) {
+            setAuthentication(accessToken);
+        }
+
+        // 다음 필터로 요청 전달
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * SecurityContext에 인증 정보 설정
+     * @param accessToken 유효한 Access Token
+     */
+    private void setAuthentication(String accessToken) {
+        try {
+            // Access Token을 통해 인증 객체 생성
+            Authentication authentication = tokenProvider.getAuthentication(accessToken);
+
+            // 인증 정보를 SecurityContext에 설정
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        } catch (Exception e) {
+            log.error("로그인 인증 실패: {}", e.getMessage()); // 인증 실패 로그
+            SecurityContextHolder.clearContext(); // 인증 실패 시 컨텍스트 초기화
+        }
+    }
+
+    /**
+     * Authorization 헤더에서 토큰을 추출
+     * @param request HTTP 요청
+     * @return Bearer 토큰 문자열 (없으면 null)
+     */
+    private String resolveToken(HttpServletRequest request) {
+        String authorization = request.getHeader("Authorization");
+
+        // Authorization 헤더 검증
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            return null; // 토큰이 없으면 null 반환
+        }
+
+        return authorization.substring(7); // "Bearer " 이후의 토큰 부분만 반환
+    }
+}

--- a/src/main/java/com/gdg/homepage/common/security/jwt/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/gdg/homepage/common/security/jwt/filter/TokenAuthenticationFilter.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -24,17 +25,16 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-        // Access Token 추출
         String accessToken = resolveToken(request);
 
-        // Access Token 검증 및 인증 설정
         if (accessToken != null && tokenProvider.validateToken(accessToken)) {
             setAuthentication(accessToken);
+        } else {
         }
 
-        // 다음 필터로 요청 전달
         filterChain.doFilter(request, response);
     }
+
 
     /**
      * SecurityContext에 인증 정보 설정
@@ -59,14 +59,14 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
      * @param request HTTP 요청
      * @return Bearer 토큰 문자열 (없으면 null)
      */
-    private String resolveToken(HttpServletRequest request) {
-        String authorization = request.getHeader("Authorization");
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
 
-        // Authorization 헤더 검증
-        if (authorization == null || !authorization.startsWith("Bearer ")) {
-            return null; // 토큰이 없으면 null 반환
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
         }
 
-        return authorization.substring(7); // "Bearer " 이후의 토큰 부분만 반환
+        return null;
     }
+
 }

--- a/src/main/java/com/gdg/homepage/common/security/jwt/provider/CustomJWTException.java
+++ b/src/main/java/com/gdg/homepage/common/security/jwt/provider/CustomJWTException.java
@@ -1,0 +1,19 @@
+package com.gdg.homepage.common.security.jwt.provider;
+
+public class CustomJWTException extends RuntimeException {
+
+    // 기본 생성자
+    public CustomJWTException() {
+        super("JWT 처리 중 오류가 발생했습니다.");
+    }
+
+    // 사용자 정의 메시지를 전달할 수 있는 생성자
+    public CustomJWTException(String message) {
+        super(message);  // 부모 클래스의 생성자를 호출하여 메시지 전달
+    }
+
+    // 예외 원인을 함께 전달할 수 있는 생성자
+    public CustomJWTException(String message, Throwable cause) {
+        super(message, cause);  // 부모 클래스의 생성자를 호출하여 메시지와 원인 전달
+    }
+}

--- a/src/main/java/com/gdg/homepage/common/security/jwt/provider/JwtTokenProvider.java
+++ b/src/main/java/com/gdg/homepage/common/security/jwt/provider/JwtTokenProvider.java
@@ -1,0 +1,139 @@
+package com.gdg.homepage.common.security.jwt.provider;
+
+import com.gdg.homepage.landing.member.domain.Member;
+import com.gdg.homepage.landing.member.dto.CustomUserDetails;
+import com.gdg.homepage.landing.member.repository.MemberRepository;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.SecretKey;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    @Value("${jwt.key}")
+    private String key;
+    private SecretKey secretKey;
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30L;
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60L * 24 * 7;
+    private final MemberRepository memberRepository;
+
+    @PostConstruct
+    private void setSecretKey() {
+        secretKey = Keys.hmacShaKeyFor(key.getBytes());
+    }
+
+    /// AccessToken 만들기
+    public String generateAccessToken(Authentication authentication) {
+        return generateToken(authentication, ACCESS_TOKEN_EXPIRE_TIME);
+    }
+
+
+    /// Refresh token 발급
+    public void generateRefreshToken(Authentication authentication, String accessToken) {
+        String refreshToken = generateToken(authentication, REFRESH_TOKEN_EXPIRE_TIME);
+    }
+
+    ///
+    public String generateToken(Authentication authentication, long expireTime) {
+        Date now = new Date();
+        Date expiredDate = new Date(now.getTime() + expireTime);
+
+        // 권한 리스트 추출
+        List<String> authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)  // 권한을 String으로 변환
+                .collect(Collectors.toList());
+
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("roles", authorities);
+        claims.put("userId", customUserDetails.getId());
+        return Jwts.builder()
+                .setSubject(authentication.getName())// 사용자 이름 (subject)
+                .setClaims(claims)
+                .setIssuedAt(now)                                // 발급 시간
+                .setExpiration(expiredDate)                      // 만료 시간
+                .signWith(secretKey, SignatureAlgorithm.HS512)   // 서명
+                .compact();
+        // 토큰 반환
+    }
+
+    ///
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseClaims(token);  // JWT 클레임 파싱
+
+        // 권한 정보 가져오기
+        Object roles = claims.get("roles");  // JWT에서 roles 정보 가져오기
+        List<String> authoritiesList = new ArrayList<>();
+
+        if (roles instanceof List) {
+            // roles가 List 형식일 때
+            authoritiesList = (List<String>) roles;
+        } else if (roles instanceof String) {
+            // roles가 String 형식일 때 (콤마로 구분된 역할)
+            authoritiesList = Arrays.asList(((String) roles).split(","));
+        }
+
+        // 권한을 SimpleGrantedAuthority로 변환
+        Collection<? extends GrantedAuthority> authorities = authoritiesList.stream()
+                .map(role -> new SimpleGrantedAuthority("ROLE_" + role))  // ROLE_ 접두사 추가
+                .collect(Collectors.toList());
+
+        // userId를 Long으로 안전하게 변환
+        Long userId = claims.get("userId", Long.class);
+
+        // 해당 userId로 Member를 조회
+        Member member = memberRepository.findById(userId)
+                .orElseThrow();
+        CustomUserDetails userDetails = new CustomUserDetails(member);
+
+        // UsernamePasswordAuthenticationToken 반환
+        return new UsernamePasswordAuthenticationToken(userDetails, token, authorities);
+    }
+
+
+    /// 토큰 검증
+    public boolean validateToken(String token) {
+        if (!StringUtils.hasText(token)) {
+            return false;
+        }
+
+        Claims claims = parseClaims(token);
+        return claims.getExpiration().after(new Date());
+    }
+
+    /// 토큰 Parse 하기
+    private Claims parseClaims(String token) {
+        try {
+            // JWT 파서를 빌드하고 서명된 토큰을 파싱
+            return Jwts.parserBuilder()
+                    .setSigningKey(secretKey)  // 서명 키를 설정
+                    .build()
+                    .parseClaimsJws(token)  // 서명된 JWT 토큰을 파싱
+                    .getBody();  // Claims 객체 반환
+        } catch (ExpiredJwtException e) {
+            // 만료된 JWT 토큰의 경우 만료된 Claims 반환
+            return e.getClaims();
+        } catch (MalformedJwtException e) {
+            // 잘못된 JWT 토큰 형식일 경우 예외 처리
+            throw new CustomJWTException("잘못된 토큰 형식입니다.");
+        }
+    }
+
+}
+

--- a/src/main/java/com/gdg/homepage/landing/admin/controller/AdminApi.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/controller/AdminApi.java
@@ -1,4 +1,66 @@
 package com.gdg.homepage.landing.admin.controller;
 
+import com.gdg.homepage.common.response.ApiResponse;
+import com.gdg.homepage.common.response.CustomException;
+import com.gdg.homepage.common.response.ErrorCode;
+import com.gdg.homepage.landing.admin.dto.JoinPeriodRequest;
+import com.gdg.homepage.landing.admin.dto.JoinPeriodResponse;
+import com.gdg.homepage.landing.admin.service.AdminServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin/joinPeriod")
+@RequiredArgsConstructor
 public class AdminApi {
+
+    private final AdminServiceImpl adminService;
+
+    // 가입 일정 생성
+    @PostMapping("/create")
+    public ApiResponse<String> createJoinPeriod(@RequestBody JoinPeriodRequest JoinPeriodRequest) {
+        try {
+            adminService.createJoinPeriod(JoinPeriodRequest);
+            return ApiResponse.created("JoinPeriod is created.");
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // 가입 일정 수정
+    @PutMapping("/update/{id}")
+    public ApiResponse<JoinPeriodResponse> updateJoinPeriod(@PathVariable("id") Long id, @RequestBody JoinPeriodRequest JoinPeriodRequest) {
+        try {
+            JoinPeriodResponse JoinPeriodResponseDto = adminService.updateJoinPeriod(id, JoinPeriodRequest);
+            return ApiResponse.ok(JoinPeriodResponseDto);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+    // 가입 목록 조회
+    @GetMapping("/all")
+    public ApiResponse<List<JoinPeriodResponse>> getAllJoinPeriods() {
+        try {
+            List<JoinPeriodResponse> JoinPeriodResponseDtos = adminService.getAllJoinPeriods();
+            return ApiResponse.ok(JoinPeriodResponseDtos);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // 가입 조기 종료
+    @DeleteMapping("/terminate/{id}")
+    public ApiResponse<String> terminateJoinPeriod(@PathVariable("id") Long id) {
+        try {
+            adminService.terminateJoinPeriod(id);
+            return ApiResponse.ok("JoinPeriod is terminated.");
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+
+
 }

--- a/src/main/java/com/gdg/homepage/landing/admin/controller/MemberAdminApi.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/controller/MemberAdminApi.java
@@ -3,6 +3,7 @@ package com.gdg.homepage.landing.admin.controller;
 import com.gdg.homepage.common.response.ApiResponse;
 import com.gdg.homepage.common.response.page.PageRequest;
 import com.gdg.homepage.common.response.page.PageResponse;
+import com.gdg.homepage.landing.admin.dto.MemberApproveRequest;
 import com.gdg.homepage.landing.admin.dto.MemberDetailResponse;
 import com.gdg.homepage.landing.admin.dto.MemberListResponse;
 import com.gdg.homepage.landing.admin.dto.MemberUpgradeRequest;
@@ -35,6 +36,13 @@ public class MemberAdminApi {
     @GetMapping("/list/not")
     public ApiResponse<PageResponse<MemberListResponse>> getMemberListNotApproved(PageRequest pageRequest) {
         return ApiResponse.ok(adminService.findAllNotApproved(pageRequest));
+    }
+
+    // 멤버 승인하기
+    @PutMapping("/approve")
+    public ApiResponse<String> approveRole(@RequestBody @Valid MemberApproveRequest request){
+        adminService.approveMember(request);
+        return ApiResponse.created("승인 되었습니다.");
     }
 
     // 멤버 권한 수정하기

--- a/src/main/java/com/gdg/homepage/landing/admin/controller/MemberAdminApi.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/controller/MemberAdminApi.java
@@ -1,0 +1,46 @@
+package com.gdg.homepage.landing.admin.controller;
+
+import com.gdg.homepage.common.response.ApiResponse;
+import com.gdg.homepage.common.response.page.PageRequest;
+import com.gdg.homepage.common.response.page.PageResponse;
+import com.gdg.homepage.landing.admin.dto.MemberDetailResponse;
+import com.gdg.homepage.landing.admin.dto.MemberListResponse;
+import com.gdg.homepage.landing.admin.dto.MemberUpgradeRequest;
+import com.gdg.homepage.landing.admin.service.MemberAdminService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/admin/v1/member")
+@RequiredArgsConstructor
+public class MemberAdminApi {
+
+    private final MemberAdminService adminService;
+
+
+    // 승인된 멤버 가져오기
+    @GetMapping("/list")
+    public ApiResponse<PageResponse<MemberListResponse>> getMemberList(PageRequest pageRequest) {
+        return ApiResponse.ok(adminService.findAll(pageRequest));
+    }
+
+    // 멤버 상세 조회하기
+    @GetMapping("/{id}")
+    public ApiResponse<MemberDetailResponse> getMemberDetail(@PathVariable Long id) {
+        return ApiResponse.ok(adminService.loadMember(id));
+    }
+
+    // 미승인된 멤버 가져오기
+    @GetMapping("/list/not")
+    public ApiResponse<PageResponse<MemberListResponse>> getMemberListNotApproved(PageRequest pageRequest) {
+        return ApiResponse.ok(adminService.findAllNotApproved(pageRequest));
+    }
+
+    // 멤버 권한 수정하기
+    @PutMapping()
+    public ApiResponse<String> changeRole(@RequestBody @Valid MemberUpgradeRequest request) {
+        adminService.changeRole(request);
+        return ApiResponse.ok("권한 수정 성공되었습니다.");
+    }
+}

--- a/src/main/java/com/gdg/homepage/landing/admin/controller/MemberAdminApi.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/controller/MemberAdminApi.java
@@ -8,8 +8,10 @@ import com.gdg.homepage.landing.admin.dto.MemberDetailResponse;
 import com.gdg.homepage.landing.admin.dto.MemberListResponse;
 import com.gdg.homepage.landing.admin.dto.MemberUpgradeRequest;
 import com.gdg.homepage.landing.admin.service.MemberAdminService;
+import com.gdg.homepage.landing.member.dto.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -40,14 +42,16 @@ public class MemberAdminApi {
 
     // 멤버 승인하기
     @PutMapping("/approve")
-    public ApiResponse<String> approveRole(@RequestBody @Valid MemberApproveRequest request){
+    public ApiResponse<String> approveRole(@AuthenticationPrincipal CustomUserDetails memberDetails, @RequestBody @Valid MemberApproveRequest request){
+        request.setAdminId(memberDetails.getId());
         adminService.approveMember(request);
         return ApiResponse.created("승인 되었습니다.");
     }
 
     // 멤버 권한 수정하기
     @PutMapping()
-    public ApiResponse<String> changeRole(@RequestBody @Valid MemberUpgradeRequest request) {
+    public ApiResponse<String> changeRole(@AuthenticationPrincipal CustomUserDetails memberDetails, @RequestBody @Valid MemberUpgradeRequest request) {
+        request.setAdminId(memberDetails.getId());
         adminService.changeRole(request);
         return ApiResponse.ok("권한 수정 성공되었습니다.");
     }

--- a/src/main/java/com/gdg/homepage/landing/admin/domain/JoinPeriod.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/domain/JoinPeriod.java
@@ -1,12 +1,18 @@
 package com.gdg.homepage.landing.admin.domain;
 
+import com.gdg.homepage.landing.admin.dto.JoinPeriodRequest;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+@Getter
+@NoArgsConstructor
 @Entity
 public class JoinPeriod {
 
@@ -20,5 +26,31 @@ public class JoinPeriod {
 
     private LocalDateTime endDate;
 
+    private int maxMember;
+
     private Boolean status;
+
+    @Builder
+    public JoinPeriod(String title, LocalDateTime startDate, LocalDateTime endDate, int maxMember, Boolean status) {
+        this.title = title;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.maxMember = maxMember;
+        this.status = status;
+    }
+
+
+    // 가입 일정 수정 메소드
+    public void updateJoinPeriod(JoinPeriodRequest joinPeriod) {
+        this.title = joinPeriod.getTitle();
+        this.startDate = joinPeriod.getStartDate();
+        this.endDate = joinPeriod.getEndDate();
+        this.maxMember = joinPeriod.getMaxMember();
+    }
+
+    // 가입 일정 종료 메서드
+    public void terminateJoinPeriod() {
+        this.status = false;
+    }
+
 }

--- a/src/main/java/com/gdg/homepage/landing/admin/dto/JoinPeriodRequest.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/dto/JoinPeriodRequest.java
@@ -1,0 +1,15 @@
+package com.gdg.homepage.landing.admin.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class JoinPeriodRequest {
+    private String title;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private int maxMember;
+
+
+}

--- a/src/main/java/com/gdg/homepage/landing/admin/dto/JoinPeriodResponse.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/dto/JoinPeriodResponse.java
@@ -1,0 +1,28 @@
+package com.gdg.homepage.landing.admin.dto;
+
+import com.gdg.homepage.landing.admin.domain.JoinPeriod;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class JoinPeriodResponse {
+    private String title;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private int maxMember;
+    private Boolean status;
+
+    
+    public static JoinPeriodResponse from(JoinPeriod joinPeriod) {
+        return JoinPeriodResponse.builder()
+                .title(joinPeriod.getTitle())
+                .startDate(joinPeriod.getStartDate())
+                .endDate(joinPeriod.getEndDate())
+                .maxMember(joinPeriod.getMaxMember())
+                .status(joinPeriod.getStatus())
+                .build();
+    }
+
+}

--- a/src/main/java/com/gdg/homepage/landing/admin/dto/MemberApproveRequest.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/dto/MemberApproveRequest.java
@@ -1,11 +1,16 @@
 package com.gdg.homepage.landing.admin.dto;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
 public class MemberApproveRequest {
 
     private Long adminId;
+
+    @NotNull(message = "회원 ID는 필수입니다.")
+    @Min(value = 1, message = "회원 ID는 1 이상이어야 합니다.")
     private Long userId;
 
 }

--- a/src/main/java/com/gdg/homepage/landing/admin/dto/MemberApproveRequest.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/dto/MemberApproveRequest.java
@@ -1,0 +1,11 @@
+package com.gdg.homepage.landing.admin.dto;
+
+import lombok.Data;
+
+@Data
+public class MemberApproveRequest {
+
+    private Long adminId;
+    private Long userId;
+
+}

--- a/src/main/java/com/gdg/homepage/landing/admin/dto/MemberDetailResponse.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/dto/MemberDetailResponse.java
@@ -1,0 +1,33 @@
+package com.gdg.homepage.landing.admin.dto;
+
+import com.gdg.homepage.landing.member.domain.Member;
+import com.gdg.homepage.landing.register.domain.RegisterSnippet;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MemberDetailResponse {
+
+    /// List에 있던 정보
+    private MemberListResponse member;
+    private String major;
+
+    private String field;
+    private String stack;
+
+    public static MemberDetailResponse from(Member member) {
+
+        RegisterSnippet snippet = member.getRegister().getSnippet();
+
+        return MemberDetailResponse.builder()
+                .member(MemberListResponse.from(member))
+                .major(snippet.getMajor())
+                .field(String.valueOf(snippet.getTechField()))
+                .stack(String.valueOf(snippet.getTechStack()))
+                .build();
+
+    }
+
+
+}

--- a/src/main/java/com/gdg/homepage/landing/admin/dto/MemberListResponse.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/dto/MemberListResponse.java
@@ -1,7 +1,9 @@
 package com.gdg.homepage.landing.admin.dto;
 
 import com.gdg.homepage.landing.member.domain.Member;
+import com.gdg.homepage.landing.member.domain.MemberRole;
 import com.gdg.homepage.landing.register.domain.RegisterSnippet;
+import com.gdg.homepage.landing.register.domain.Role;
 import lombok.Builder;
 import lombok.Data;
 
@@ -18,20 +20,27 @@ public class MemberListResponse {
     private String studentId;
     private String phoneNumber;
     private String role;
-
+    private boolean approved;
 
     // from
     public static MemberListResponse from(Member member) {
 
         RegisterSnippet snippet = member.getRegister().getSnippet();
 
+        String role = String.valueOf(member.getRole());
+
+        if (member.getRole().equals(MemberRole.NON_MEMBER)){
+            role = String.valueOf(member.getRegister().getRegisteredRole());
+        }
         return MemberListResponse.builder()
                 .memberId(member.getId())
                 .email(member.getEmail())
-                .name(snippet.getName())
+                .name(member.getName())
                 .grade(snippet.getGrade())
                 .studentId(snippet.getStudentId())
-                .phoneNumber(snippet.getPhoneNumber())
+                .phoneNumber(member.getPhoneNumber())
+                .role(role)
+                .approved(member.getRegister().isApproved())
                 .build();
     }
 

--- a/src/main/java/com/gdg/homepage/landing/admin/dto/MemberListResponse.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/dto/MemberListResponse.java
@@ -1,0 +1,44 @@
+package com.gdg.homepage.landing.admin.dto;
+
+import com.gdg.homepage.landing.member.domain.Member;
+import com.gdg.homepage.landing.register.domain.RegisterSnippet;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class MemberListResponse {
+
+    private Long memberId;
+    private String email;
+    private String name;
+    private int grade;
+    private String studentId;
+    private String phoneNumber;
+    private String role;
+
+
+    // from
+    public static MemberListResponse from(Member member) {
+
+        RegisterSnippet snippet = member.getRegister().getSnippet();
+
+        return MemberListResponse.builder()
+                .memberId(member.getId())
+                .email(member.getEmail())
+                .name(snippet.getName())
+                .grade(snippet.getGrade())
+                .studentId(snippet.getStudentId())
+                .phoneNumber(snippet.getPhoneNumber())
+                .build();
+    }
+
+    // from
+    public static List<MemberListResponse> from(List<Member> members) {
+
+        return members.stream()
+                .map(MemberListResponse::from).toList();
+    }
+}

--- a/src/main/java/com/gdg/homepage/landing/admin/dto/MemberUpgradeRequest.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/dto/MemberUpgradeRequest.java
@@ -1,0 +1,22 @@
+package com.gdg.homepage.landing.admin.dto;
+
+import com.gdg.homepage.landing.member.domain.MemberRole;
+import lombok.Data;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+@Data
+public class MemberUpgradeRequest {
+
+    @NotNull(message = "관리자 ID는 필수입니다.")
+    @Min(value = 1, message = "관리자 ID는 1 이상이어야 합니다.")
+    private Long adminId;
+
+    @NotNull(message = "회원 ID는 필수입니다.")
+    @Min(value = 1, message = "회원 ID는 1 이상이어야 합니다.")
+    private Long memberId;
+
+    @NotNull(message = "변경할 역할은 필수입니다.")
+    private MemberRole role;
+}

--- a/src/main/java/com/gdg/homepage/landing/admin/dto/MemberUpgradeRequest.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/dto/MemberUpgradeRequest.java
@@ -9,8 +9,6 @@ import jakarta.validation.constraints.NotNull;
 @Data
 public class MemberUpgradeRequest {
 
-    @NotNull(message = "관리자 ID는 필수입니다.")
-    @Min(value = 1, message = "관리자 ID는 1 이상이어야 합니다.")
     private Long adminId;
 
     @NotNull(message = "회원 ID는 필수입니다.")

--- a/src/main/java/com/gdg/homepage/landing/admin/repository/JoinPeriodRepository.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/repository/JoinPeriodRepository.java
@@ -2,6 +2,14 @@ package com.gdg.homepage.landing.admin.repository;
 
 import com.gdg.homepage.landing.admin.domain.JoinPeriod;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 public interface JoinPeriodRepository extends JpaRepository<JoinPeriod, Long> {
+
+    @Query("SELECT jp FROM JoinPeriod jp WHERE jp.startDate <= :now AND jp.endDate >= :now")
+    Optional<JoinPeriod> findActiveJoinPeriod(@Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/gdg/homepage/landing/admin/service/AdminService.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/service/AdminService.java
@@ -1,7 +1,9 @@
 package com.gdg.homepage.landing.admin.service;
 
+import com.gdg.homepage.landing.admin.domain.JoinPeriod;
 import com.gdg.homepage.landing.admin.dto.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface AdminService {
@@ -18,5 +20,6 @@ public interface AdminService {
     // 가입 조기 종료
     void terminateJoinPeriod(Long id);
 
+    JoinPeriod checkJoinPeriod(LocalDateTime now);
 
 }

--- a/src/main/java/com/gdg/homepage/landing/admin/service/AdminService.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/service/AdminService.java
@@ -1,0 +1,22 @@
+package com.gdg.homepage.landing.admin.service;
+
+import com.gdg.homepage.landing.admin.dto.*;
+
+import java.util.List;
+
+public interface AdminService {
+    // ** 가입 ***
+    // 가입 일정 생성
+    void createJoinPeriod(JoinPeriodRequest joinPeriodRequest);
+
+    // 가입 일정 수정
+   JoinPeriodResponse updateJoinPeriod(Long id, JoinPeriodRequest joinPeriodRequest);
+
+    // 가입 기간 목록 조회
+    List<JoinPeriodResponse> getAllJoinPeriods();
+
+    // 가입 조기 종료
+    void terminateJoinPeriod(Long id);
+
+
+}

--- a/src/main/java/com/gdg/homepage/landing/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/service/AdminServiceImpl.java
@@ -1,0 +1,68 @@
+package com.gdg.homepage.landing.admin.service;
+
+import com.gdg.homepage.common.response.CustomException;
+import com.gdg.homepage.common.response.ErrorCode;
+import com.gdg.homepage.landing.admin.domain.JoinPeriod;
+import com.gdg.homepage.landing.admin.dto.JoinPeriodRequest;
+import com.gdg.homepage.landing.admin.dto.JoinPeriodResponse;
+import com.gdg.homepage.landing.admin.repository.JoinPeriodRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminServiceImpl implements AdminService {
+
+    private final JoinPeriodRepository joinPeriodRepository;
+
+    @Override
+    public void createJoinPeriod(JoinPeriodRequest joinPeriodRequest) {
+        // 가입 기간 생성
+        JoinPeriod joinPeriod=JoinPeriod.builder()
+                .title(joinPeriodRequest.getTitle())
+                .startDate(joinPeriodRequest.getStartDate())
+                .endDate(joinPeriodRequest.getEndDate())
+                .maxMember(joinPeriodRequest.getMaxMember())
+                .status(true)
+                .build();
+
+        joinPeriodRepository.save(joinPeriod);
+    }
+
+    @Override
+    public JoinPeriodResponse updateJoinPeriod(Long id, JoinPeriodRequest joinPeriodRequest) {
+        //
+        JoinPeriod joinPeriod = joinPeriodRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_END_POINT));
+        // 요청 값이 존재하면 수정
+        if(joinPeriodRequest!=null) {
+            joinPeriod.updateJoinPeriod(joinPeriodRequest);
+        }
+        JoinPeriod updatedJoinPeriod = joinPeriodRepository.save(joinPeriod);
+        return JoinPeriodResponse.from(updatedJoinPeriod);
+    }
+
+    @Override
+    public List<JoinPeriodResponse> getAllJoinPeriods() {
+        List<JoinPeriod> joinPeriods = joinPeriodRepository.findAll();
+        return joinPeriods.stream()
+                .map(joinPeriod -> JoinPeriodResponse.from(joinPeriod))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void terminateJoinPeriod(Long id) {
+        JoinPeriod joinPeriod = joinPeriodRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_END_POINT));
+
+        joinPeriod.terminateJoinPeriod();  // status 값을 false로 변경
+        joinPeriodRepository.save(joinPeriod); // 변경 사항 저장
+    }
+
+}

--- a/src/main/java/com/gdg/homepage/landing/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/service/AdminServiceImpl.java
@@ -6,11 +6,13 @@ import com.gdg.homepage.landing.admin.domain.JoinPeriod;
 import com.gdg.homepage.landing.admin.dto.JoinPeriodRequest;
 import com.gdg.homepage.landing.admin.dto.JoinPeriodResponse;
 import com.gdg.homepage.landing.admin.repository.JoinPeriodRepository;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -63,6 +65,12 @@ public class AdminServiceImpl implements AdminService {
 
         joinPeriod.terminateJoinPeriod();  // status 값을 false로 변경
         joinPeriodRepository.save(joinPeriod); // 변경 사항 저장
+    }
+
+    @Override
+    public JoinPeriod checkJoinPeriod(LocalDateTime now) {
+        return joinPeriodRepository.findActiveJoinPeriod(now)
+                .orElseThrow(() -> new EntityNotFoundException("현재 시간에 대한 가입기간 설정이 존재하지 않습니다."));
     }
 
 }

--- a/src/main/java/com/gdg/homepage/landing/admin/service/MemberAdminService.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/service/MemberAdminService.java
@@ -3,6 +3,7 @@ package com.gdg.homepage.landing.admin.service;
 
 import com.gdg.homepage.common.response.page.PageRequest;
 import com.gdg.homepage.common.response.page.PageResponse;
+import com.gdg.homepage.landing.admin.dto.MemberApproveRequest;
 import com.gdg.homepage.landing.admin.dto.MemberDetailResponse;
 import com.gdg.homepage.landing.admin.dto.MemberListResponse;
 import com.gdg.homepage.landing.admin.dto.MemberUpgradeRequest;
@@ -32,6 +33,9 @@ public interface MemberAdminService {
 
     // 총 멤버 수 갸져오기
     int getTotalMembers();
+
+    // 승인하기
+    void approveMember(MemberApproveRequest request);
 
     // 회원 탈퇴 시키기
     void removeMember(Long memberId);

--- a/src/main/java/com/gdg/homepage/landing/admin/service/MemberAdminService.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/service/MemberAdminService.java
@@ -1,0 +1,44 @@
+package com.gdg.homepage.landing.admin.service;
+
+
+import com.gdg.homepage.common.response.page.PageRequest;
+import com.gdg.homepage.common.response.page.PageResponse;
+import com.gdg.homepage.landing.admin.dto.MemberDetailResponse;
+import com.gdg.homepage.landing.admin.dto.MemberListResponse;
+import com.gdg.homepage.landing.admin.dto.MemberUpgradeRequest;
+
+public interface MemberAdminService {
+    /*
+        회원 목록 조회 (승인)
+        회원 목록 조회 (승인 대기중)
+        회원 역할 변경 (Organizer만)
+        회원 탈퇴 (Organizer, Team Member만)
+        회원 조회
+        총 멤버 수 가져오기
+        탈퇴 인원 수 가져오기
+     */
+
+    // 회원 목록 조회 (승인)
+    PageResponse<MemberListResponse> findAll(PageRequest pageRequest);
+
+    // 회원 목록 조회 (미승인)
+    PageResponse<MemberListResponse> findAllNotApproved(PageRequest pageRequest);
+
+    // 회원 역할 변경
+    void changeRole(MemberUpgradeRequest request);
+
+    // 회원 개인정보 상세 조회하기
+    MemberDetailResponse loadMember(Long memberId);
+
+    // 총 멤버 수 갸져오기
+    int getTotalMembers();
+
+    // 회원 탈퇴 시키기
+    void removeMember(Long memberId);
+
+    // 최근 탈퇴 인원 수 가져오기
+    // 최근 한 달을 기준으로 잡는다.
+    int findRecentWithdrawnMembers();
+
+
+}

--- a/src/main/java/com/gdg/homepage/landing/admin/service/MemberAdminServiceImpl.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/service/MemberAdminServiceImpl.java
@@ -2,6 +2,7 @@ package com.gdg.homepage.landing.admin.service;
 
 import com.gdg.homepage.common.response.page.PageRequest;
 import com.gdg.homepage.common.response.page.PageResponse;
+import com.gdg.homepage.landing.admin.dto.MemberApproveRequest;
 import com.gdg.homepage.landing.member.domain.Member;
 import com.gdg.homepage.landing.admin.dto.MemberDetailResponse;
 import com.gdg.homepage.landing.admin.dto.MemberListResponse;
@@ -77,6 +78,21 @@ public class MemberAdminServiceImpl implements MemberAdminService {
     @Override
     public int getTotalMembers() {
         return repository.findAll().size();
+    }
+
+    @Override
+    public void approveMember(MemberApproveRequest request) {
+        Member admin = repository.findById(request.getAdminId())
+                .orElseThrow(() -> new EntityNotFoundException("해당하는 어드민이 존재하지 않습니다."));
+
+        Member member = repository.findById(request.getUserId())
+                .orElseThrow(() -> new EntityNotFoundException("승인할 멤버가 존재하지 않습니다."));
+
+        // 승인
+        member.getRegister().approve();
+
+        // 역할 변경
+        member.changeRole(admin, member);
     }
 
     @Override

--- a/src/main/java/com/gdg/homepage/landing/admin/service/MemberAdminServiceImpl.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/service/MemberAdminServiceImpl.java
@@ -1,0 +1,94 @@
+package com.gdg.homepage.landing.admin.service;
+
+import com.gdg.homepage.common.response.page.PageRequest;
+import com.gdg.homepage.common.response.page.PageResponse;
+import com.gdg.homepage.landing.member.domain.Member;
+import com.gdg.homepage.landing.admin.dto.MemberDetailResponse;
+import com.gdg.homepage.landing.admin.dto.MemberListResponse;
+import com.gdg.homepage.landing.admin.dto.MemberUpgradeRequest;
+import com.gdg.homepage.landing.member.repository.MemberRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberAdminServiceImpl implements MemberAdminService {
+
+    private final MemberRepository repository;
+
+    @Override
+    public PageResponse<MemberListResponse> findAll(PageRequest pageRequest) {
+
+        Pageable pageable = org.springframework.data.domain.PageRequest.of(
+                pageRequest.getPage() - 1,
+                pageRequest.getSize(),
+                Sort.by(Sort.Direction.DESC, "id")
+        );
+
+        Page<Member> result = repository.findAllMemberApproved(pageable);
+        List<MemberListResponse> dtoList = MemberListResponse.from(result.getContent());
+
+        return new PageResponse<>(dtoList, pageRequest, result.getTotalElements());
+    }
+
+    @Override
+    public PageResponse<MemberListResponse> findAllNotApproved(PageRequest pageRequest) {
+
+        Pageable pageable = org.springframework.data.domain.PageRequest.of(
+                pageRequest.getPage() - 1,
+                pageRequest.getSize(),
+                Sort.by(Sort.Direction.DESC, "id")
+        );
+
+        Page<Member> result = repository.findAllMemberNotApproved(pageable);
+        List<MemberListResponse> dtoList = MemberListResponse.from(result.getContent());
+
+        return new PageResponse<>(dtoList,pageRequest, result.getTotalElements());
+    }
+
+    @Override
+    public void changeRole(MemberUpgradeRequest request) {
+        Member admin = repository.findById(request.getAdminId())
+                .orElseThrow(() -> new EntityNotFoundException("해당하는 어드민이 존재하지 않습니다."));
+
+        Member member = repository.findById(request.getMemberId())
+                .orElseThrow(() -> new EntityNotFoundException("권한을 수정할 멤버가 존재하지 않습니다."));
+
+        // 권한 수정
+        member.upgradeRole(admin, request.getRole());
+    }
+
+    @Override
+    public MemberDetailResponse loadMember(Long memberId) {
+        Member member = repository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("해당하는 멤버가 존재하지 않습니다."));
+
+        return MemberDetailResponse.from(member);
+    }
+
+    @Override
+    public int getTotalMembers() {
+        return repository.findAll().size();
+    }
+
+    @Override
+    public void removeMember(Long memberId) {
+        repository.deleteById(memberId);
+    }
+
+    @Override
+    public int findRecentWithdrawnMembers() {
+        /// 최근 탈퇴한 인원에 대한 정보를 DB에 저장해야한다.
+        return 0;
+    }
+
+
+}

--- a/src/main/java/com/gdg/homepage/landing/admin/service/adminService.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/service/adminService.java
@@ -1,4 +1,0 @@
-package com.gdg.homepage.landing.admin.service;
-
-public interface adminService {
-}

--- a/src/main/java/com/gdg/homepage/landing/admin/service/adminServiceImpl.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/service/adminServiceImpl.java
@@ -1,4 +1,0 @@
-package com.gdg.homepage.landing.admin.service;
-
-public class adminServiceImpl implements adminService {
-}

--- a/src/main/java/com/gdg/homepage/landing/faq/controller/FAQApi.java
+++ b/src/main/java/com/gdg/homepage/landing/faq/controller/FAQApi.java
@@ -1,4 +1,64 @@
 package com.gdg.homepage.landing.faq.controller;
 
+import com.gdg.homepage.common.response.ApiResponse;
+import com.gdg.homepage.common.response.CustomException;
+import com.gdg.homepage.common.response.ErrorCode;
+import com.gdg.homepage.landing.faq.dto.FAQRequest;
+import com.gdg.homepage.landing.faq.dto.FAQResponse;
+import com.gdg.homepage.landing.faq.service.FAQServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin/faq")
+@RequiredArgsConstructor
 public class FAQApi {
+
+    private final FAQServiceImpl FAQService;
+
+    // FAQ 추가
+    @PostMapping("/create")
+    public ApiResponse<FAQResponse> createFAQ(@RequestBody FAQRequest faqRequest) {
+        try {
+            FAQResponse faqResponseDto = FAQService.createFAQ(faqRequest);
+            return ApiResponse.created(faqResponseDto);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // FAQ 수정
+    @PutMapping("/update/{id}")
+    public ApiResponse<FAQResponse> updateFAQ(@PathVariable("id") Long id, @RequestBody FAQRequest faqRequest) {
+        try {
+            FAQResponse faqResponseDto = FAQService.updateFAQ(id, faqRequest);
+            return ApiResponse.ok(faqResponseDto);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // FAQ 삭제
+    @DeleteMapping("/delete/{id}")
+    public ApiResponse<String> deleteFAQ(@PathVariable("id") Long id) {
+        try {
+            FAQService.deleteFAQ(id);
+            return ApiResponse.ok("FAQ is deleted.");
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // FAQ 목록 조회
+    @GetMapping("/all")
+    public ApiResponse<List<FAQResponse>> getAllFAQs() {
+        try {
+            List<FAQResponse> faqResponseDtos = FAQService.getAllFAQs();
+            return ApiResponse.ok(faqResponseDtos);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/gdg/homepage/landing/faq/domain/FAQ.java
+++ b/src/main/java/com/gdg/homepage/landing/faq/domain/FAQ.java
@@ -5,7 +5,12 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
+@NoArgsConstructor
 @Entity
 public class FAQ extends BaseTimeEntity {
 
@@ -17,4 +22,23 @@ public class FAQ extends BaseTimeEntity {
 
     private String answer;
 
+    @Builder
+    public FAQ(String question, String answer) {
+        this.question = question;
+        this.answer = answer;
+    }
+
+    // 질문 수정 메소드
+    public void updateQuestion(String question) {
+        if (question != null) {
+            this.question = question;
+        }
+    }
+
+    // 답변 수정 메소드
+    public void updateAnswer(String answer) {
+        if (answer != null) {
+            this.answer = answer;
+        }
+    }
 }

--- a/src/main/java/com/gdg/homepage/landing/faq/dto/FAQRequest.java
+++ b/src/main/java/com/gdg/homepage/landing/faq/dto/FAQRequest.java
@@ -1,0 +1,11 @@
+package com.gdg.homepage.landing.faq.dto;
+
+import lombok.Getter;
+
+
+@Getter
+public class FAQRequest {
+    private String question;
+    private String answer;
+
+}

--- a/src/main/java/com/gdg/homepage/landing/faq/dto/FAQResponse.java
+++ b/src/main/java/com/gdg/homepage/landing/faq/dto/FAQResponse.java
@@ -1,0 +1,21 @@
+package com.gdg.homepage.landing.faq.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class FAQResponse {
+    private Long id;
+    private String question;
+    private String answer;
+
+    @Builder
+    public static FAQResponse from(Long id, String question, String answer) {
+        return FAQResponse.builder()
+                .id(id)
+                .question(question)
+                .answer(answer)
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/homepage/landing/faq/repository/FAQRepository.java
+++ b/src/main/java/com/gdg/homepage/landing/faq/repository/FAQRepository.java
@@ -2,6 +2,8 @@ package com.gdg.homepage.landing.faq.repository;
 
 import com.gdg.homepage.landing.faq.domain.FAQ;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface FAQRepository extends JpaRepository<FAQ, Long> {
 }

--- a/src/main/java/com/gdg/homepage/landing/faq/service/FAQService.java
+++ b/src/main/java/com/gdg/homepage/landing/faq/service/FAQService.java
@@ -1,4 +1,20 @@
 package com.gdg.homepage.landing.faq.service;
 
+import com.gdg.homepage.landing.faq.dto.FAQRequest;
+import com.gdg.homepage.landing.faq.dto.FAQResponse;
+
+import java.util.List;
+
 public interface FAQService {
+    // FAQ 생성
+    FAQResponse createFAQ(FAQRequest faqRequest);
+
+    // FAQ 수정
+    FAQResponse updateFAQ(Long id, FAQRequest faqRequest);
+
+    // FAQ 삭제
+    void deleteFAQ(Long id);
+
+    // FAQ 목록 조회
+    List<FAQResponse> getAllFAQs();
 }

--- a/src/main/java/com/gdg/homepage/landing/faq/service/FAQServiceImpl.java
+++ b/src/main/java/com/gdg/homepage/landing/faq/service/FAQServiceImpl.java
@@ -1,4 +1,60 @@
 package com.gdg.homepage.landing.faq.service;
 
+import com.gdg.homepage.common.response.CustomException;
+import com.gdg.homepage.common.response.ErrorCode;
+import com.gdg.homepage.landing.faq.dto.FAQRequest;
+import com.gdg.homepage.landing.faq.dto.FAQResponse;
+import com.gdg.homepage.landing.faq.domain.FAQ;
+import com.gdg.homepage.landing.faq.repository.FAQRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
 public class FAQServiceImpl implements FAQService {
+
+    private final FAQRepository faqRepository;
+
+    // FAQ 생성 - FAQResponse로 반환할 것이 없다면 void 처리할 예정
+    public FAQResponse createFAQ(FAQRequest faqRequest) {
+        FAQ faq = FAQ.builder()
+                .question(faqRequest.getQuestion())
+                .answer(faqRequest.getAnswer())
+                .build();
+        FAQ savedFaq = faqRepository.save(faq);
+        return FAQResponse.from(savedFaq.getId(), savedFaq.getQuestion(), savedFaq.getAnswer());
+    }
+
+    // FAQ 수정 - 반환할게 없다면 void 처리/ 수정 요청값을 무조건 넣어
+    public FAQResponse updateFAQ(Long id, FAQRequest faqRequest) {
+        FAQ faq = faqRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_END_POINT));
+        // 요청 값이 존재하면 수정
+        if(faqRequest.getQuestion()!=null) {
+            faq.updateQuestion(faqRequest.getQuestion());
+        }
+        if(faqRequest.getAnswer()!=null){
+            faq.updateAnswer(faqRequest.getAnswer());
+        }
+        FAQ updatedFaq = faqRepository.save(faq);
+        return FAQResponse.from(updatedFaq.getId(), updatedFaq.getQuestion(), updatedFaq.getAnswer());
+    }
+
+    // FAQ 삭제
+    public void deleteFAQ(Long id) {
+        FAQ faq = faqRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_END_POINT));
+        faqRepository.delete(faq);
+    }
+
+    // FAQ 목록 조회
+    public List<FAQResponse> getAllFAQs() {
+        List<FAQ> faqs = faqRepository.findAll();
+        return faqs.stream()
+                .map(faq -> FAQResponse.from(faq.getId(), faq.getQuestion(), faq.getAnswer()))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/gdg/homepage/landing/member/controller/MemberApi.java
+++ b/src/main/java/com/gdg/homepage/landing/member/controller/MemberApi.java
@@ -1,6 +1,8 @@
 package com.gdg.homepage.landing.member.controller;
 
 import com.gdg.homepage.common.response.ApiResponse;
+import com.gdg.homepage.landing.member.dto.MemberLoginRequest;
+import com.gdg.homepage.landing.member.dto.MemberLoginResponse;
 import com.gdg.homepage.landing.member.dto.MemberRegisterWrapper;
 import com.gdg.homepage.landing.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,11 @@ public class MemberApi {
     public ApiResponse<String> create(@RequestBody MemberRegisterWrapper wrapper) {
         memberService.registerMember(wrapper.getMember(), wrapper.getApply());
         return ApiResponse.created("성공적으로 제출되었습니다.");
+    }
+
+    @PostMapping("/login")
+    public ApiResponse<MemberLoginResponse> login(@RequestBody MemberLoginRequest request){
+        return ApiResponse.ok(memberService.login(request));
     }
 
 }

--- a/src/main/java/com/gdg/homepage/landing/member/controller/MemberApi.java
+++ b/src/main/java/com/gdg/homepage/landing/member/controller/MemberApi.java
@@ -1,15 +1,15 @@
 package com.gdg.homepage.landing.member.controller;
 
 import com.gdg.homepage.common.response.ApiResponse;
+import com.gdg.homepage.landing.admin.dto.MemberDetailResponse;
+import com.gdg.homepage.landing.member.dto.CustomUserDetails;
 import com.gdg.homepage.landing.member.dto.MemberLoginRequest;
 import com.gdg.homepage.landing.member.dto.MemberLoginResponse;
 import com.gdg.homepage.landing.member.dto.MemberRegisterWrapper;
 import com.gdg.homepage.landing.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/member")
@@ -25,8 +25,14 @@ public class MemberApi {
     }
 
     @PostMapping("/login")
-    public ApiResponse<MemberLoginResponse> login(@RequestBody MemberLoginRequest request){
+    public ApiResponse<MemberLoginResponse> login(@RequestBody MemberLoginRequest request) {
         return ApiResponse.ok(memberService.login(request));
+    }
+
+    @GetMapping("/myPage")
+    public ApiResponse<MemberDetailResponse> myPage(@AuthenticationPrincipal CustomUserDetails memberDetails) {
+
+        return ApiResponse.ok(memberService.loadMyMember(memberDetails.getId()));
     }
 
 }

--- a/src/main/java/com/gdg/homepage/landing/member/controller/MemberApi.java
+++ b/src/main/java/com/gdg/homepage/landing/member/controller/MemberApi.java
@@ -1,4 +1,25 @@
 package com.gdg.homepage.landing.member.controller;
 
+import com.gdg.homepage.common.response.ApiResponse;
+import com.gdg.homepage.landing.member.dto.MemberRegisterWrapper;
+import com.gdg.homepage.landing.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/member")
+@RequiredArgsConstructor
 public class MemberApi {
+
+    private final MemberService memberService;
+
+    @PostMapping("/register")
+    public ApiResponse<String> create(@RequestBody MemberRegisterWrapper wrapper) {
+        memberService.registerMember(wrapper.getMember(), wrapper.getApply());
+        return ApiResponse.created("성공적으로 제출되었습니다.");
+    }
+
 }

--- a/src/main/java/com/gdg/homepage/landing/member/controller/MemberApi.java
+++ b/src/main/java/com/gdg/homepage/landing/member/controller/MemberApi.java
@@ -29,6 +29,12 @@ public class MemberApi {
         return ApiResponse.ok(memberService.login(request));
     }
 
+    @PostMapping("/logout")
+    public ApiResponse<String> logout() {
+        memberService.logout();
+        return ApiResponse.ok("성공적으로 로그아웃 되었습니다.");
+    }
+
     @GetMapping("/myPage")
     public ApiResponse<MemberDetailResponse> myPage(@AuthenticationPrincipal CustomUserDetails memberDetails) {
 

--- a/src/main/java/com/gdg/homepage/landing/member/domain/Member.java
+++ b/src/main/java/com/gdg/homepage/landing/member/domain/Member.java
@@ -42,6 +42,7 @@ public class Member extends BaseTimeEntity implements UserDetails {
     @OneToOne(mappedBy = "member")
     private Register register;
 
+    private Integer passwordError;
 
     /// 생성자
     public static Member of(String email, String password, String name, String phoneNumber, Register register) {
@@ -92,6 +93,10 @@ public class Member extends BaseTimeEntity implements UserDetails {
         this.register = register;
 
         this.register.setMember(this);
+    }
+
+    public void addPasswordError() {
+        this.passwordError++;
     }
 
 

--- a/src/main/java/com/gdg/homepage/landing/member/domain/Member.java
+++ b/src/main/java/com/gdg/homepage/landing/member/domain/Member.java
@@ -80,6 +80,10 @@ public class Member extends BaseTimeEntity implements UserDetails {
             throw new IllegalStateException("ORGANIZER 만 권한을 수정할 수 있습니다.");
         }
 
+        if (!this.register.isApproved()){
+            throw new IllegalStateException("신청서를 승인받지못한 멤버는 권한을 바꿀 수 없습니다. 승인 먼저 진행해주세요");
+        }
+
         this.role = role;
     }
 

--- a/src/main/java/com/gdg/homepage/landing/member/domain/Member.java
+++ b/src/main/java/com/gdg/homepage/landing/member/domain/Member.java
@@ -3,23 +3,106 @@ package com.gdg.homepage.landing.member.domain;
 import com.gdg.homepage.common.domain.BaseTimeEntity;
 import com.gdg.homepage.landing.register.domain.Register;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
 
 @Entity
-public class Member extends BaseTimeEntity {
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class Member extends BaseTimeEntity implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String userId;
+    @Column(name = "email", nullable = false, unique = true)
+    private String email;
 
+    @Column(name = "password", nullable = false)
     private String password;
 
+    private String name;
+
+    private String phoneNumber;
+
+    @Builder.Default
     @Enumerated(EnumType.STRING)
-    private MemberRole role;
+    private MemberRole role = MemberRole.NON_MEMBER;
 
     @OneToOne(mappedBy = "member")
     private Register register;
 
 
+    /// 생성자
+    public static Member of(String email, String password, String name, String phoneNumber, Register register) {
+
+        Member member = Member.builder()
+                .email(email)
+                .password(password)
+                .name(name)
+                .phoneNumber(phoneNumber)
+                .register(register)
+                .build();
+
+        member.setRegister(register);
+        return member;
+    }
+
+    /// 비즈니스 로직
+    // 신청받은 신청서가 승인될 경우, 멤버의 역할로 바꾸는 로직
+    public void changeRole(Member admin, Member member) {
+
+        if (admin.getRole().equals(MemberRole.MEMBER) || admin.getRole().equals(MemberRole.NON_MEMBER)){
+            throw new IllegalStateException("멤버는 다른 멤버를 승인할 수 없습니다.");
+        }
+
+        if (!member.getRegister().isApproved()) {
+            throw new IllegalStateException("아직 신청서가 승인되지 않아서 역할을 수정할 수 업습니다. 관리자에게 문의하세요");
+        }
+
+        member.role = register.getRegisteredRole().toMemberRole();
+    }
+
+    //  Organizer가 특정 유저에 대한 권한을 수정할 수 있는 로직
+    public void upgradeRole(Member admin, MemberRole role) {
+        if (admin.getRole() != MemberRole.ORGANIZER) {
+            throw new IllegalStateException("ORGANIZER 만 권한을 수정할 수 있습니다.");
+        }
+
+        this.role = role;
+    }
+
+    // 비밀번호 변경 함수
+    public void changePassword(String password) {
+        this.password = password;
+    }
+
+    // Register 등록하기
+    public void setRegister(Register register) {
+        this.register = register;
+
+        this.register.setMember(this);
+    }
+
+
+    /// 시큐리티 Override
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
 }

--- a/src/main/java/com/gdg/homepage/landing/member/domain/MemberRole.java
+++ b/src/main/java/com/gdg/homepage/landing/member/domain/MemberRole.java
@@ -8,10 +8,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MemberRole {
 
-    MEMBER("Member"),
-    TEAM_MEMBER("Team_Member"),
-    ORGANIZER("Organizer"),
-    NON_MEMBER("Non_Member");
+    MEMBER("ROLE_MEMBER"),
+    TEAM_MEMBER("ROLE_TEAM_MEMBER"),
+    ORGANIZER("ROLE_ORGANIZER"),
+    NON_MEMBER("ROLE_NON_MEMBER");
 
     private final String role;
 

--- a/src/main/java/com/gdg/homepage/landing/member/domain/MemberRole.java
+++ b/src/main/java/com/gdg/homepage/landing/member/domain/MemberRole.java
@@ -1,6 +1,22 @@
 package com.gdg.homepage.landing.member.domain;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum MemberRole {
 
-    MEMBER, TEAM_MEMBER, ORGANIZER, NON_MEMBER
+    MEMBER("Member"),
+    TEAM_MEMBER("Team_Member"),
+    ORGANIZER("Organizer"),
+    NON_MEMBER("Non_Member");
+
+    private final String role;
+
+    @JsonValue
+    public String getRole() {
+        return role;
+    }
 }

--- a/src/main/java/com/gdg/homepage/landing/member/dto/CustomUserDetails.java
+++ b/src/main/java/com/gdg/homepage/landing/member/dto/CustomUserDetails.java
@@ -1,0 +1,61 @@
+package com.gdg.homepage.landing.member.dto;
+import com.gdg.homepage.landing.member.domain.Member;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    @Getter
+    private final Long id;
+    private final String email;
+    private final String password;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public CustomUserDetails(Member member) {
+        this.id = member.getId();
+        this.email = member.getEmail();
+        this.password = member.getPassword();
+        this.authorities = List.of(new SimpleGrantedAuthority("ROLE_" + member.getRole())); // ROLE_ 접두사 추가
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/gdg/homepage/landing/member/dto/MemberLoginRequest.java
+++ b/src/main/java/com/gdg/homepage/landing/member/dto/MemberLoginRequest.java
@@ -1,0 +1,13 @@
+package com.gdg.homepage.landing.member.dto;
+
+import lombok.Data;
+import lombok.Getter;
+
+@Getter
+@Data
+public class MemberLoginRequest {
+
+    private String email;
+    private String password;
+
+}

--- a/src/main/java/com/gdg/homepage/landing/member/dto/MemberLoginResponse.java
+++ b/src/main/java/com/gdg/homepage/landing/member/dto/MemberLoginResponse.java
@@ -1,0 +1,20 @@
+package com.gdg.homepage.landing.member.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MemberLoginResponse {
+
+    private String email;
+    private String jwtToken;
+
+    public static MemberLoginResponse from(String email, String jwtToken) {
+        return MemberLoginResponse.builder()
+                .email(email)
+                .jwtToken(jwtToken)
+                .build();
+    }
+
+}

--- a/src/main/java/com/gdg/homepage/landing/member/dto/MemberRegisterRequest.java
+++ b/src/main/java/com/gdg/homepage/landing/member/dto/MemberRegisterRequest.java
@@ -1,0 +1,20 @@
+package com.gdg.homepage.landing.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberRegisterRequest {
+
+    // 가입
+    private String email;
+    private String password;
+    private String name;
+    private String phoneNumber;
+
+}

--- a/src/main/java/com/gdg/homepage/landing/member/dto/MemberRegisterResponse.java
+++ b/src/main/java/com/gdg/homepage/landing/member/dto/MemberRegisterResponse.java
@@ -1,0 +1,29 @@
+package com.gdg.homepage.landing.member.dto;
+
+import com.gdg.homepage.landing.member.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberRegisterResponse {
+
+
+    private Long Id;
+    private String userId;
+    private String jwtToken;
+
+    // from
+    public static MemberRegisterResponse from (Member member){
+
+        return MemberRegisterResponse.builder()
+                .Id(member.getId())
+                .userId(member.getEmail())
+                .build();
+    }
+
+}

--- a/src/main/java/com/gdg/homepage/landing/member/dto/MemberRegisterResponse.java
+++ b/src/main/java/com/gdg/homepage/landing/member/dto/MemberRegisterResponse.java
@@ -15,7 +15,6 @@ public class MemberRegisterResponse {
 
     private Long Id;
     private String userId;
-    private String jwtToken;
 
     // from
     public static MemberRegisterResponse from (Member member){

--- a/src/main/java/com/gdg/homepage/landing/member/dto/MemberRegisterWrapper.java
+++ b/src/main/java/com/gdg/homepage/landing/member/dto/MemberRegisterWrapper.java
@@ -1,0 +1,13 @@
+package com.gdg.homepage.landing.member.dto;
+
+import com.gdg.homepage.landing.register.api.dto.RegisterRequest;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MemberRegisterWrapper {
+
+    private MemberRegisterRequest member;
+    private RegisterRequest apply;
+}

--- a/src/main/java/com/gdg/homepage/landing/member/repository/MemberRepository.java
+++ b/src/main/java/com/gdg/homepage/landing/member/repository/MemberRepository.java
@@ -1,7 +1,30 @@
 package com.gdg.homepage.landing.member.repository;
 
 import com.gdg.homepage.landing.member.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    // 아이디를 통해서 멤버 찾기
+    Optional<Member> findByEmail(String email);
+
+    // 이메일 존재하는지 체크 여부
+    boolean existsByEmail(String email);
+
+    /// 어드민 개발 기능
+
+    // 승인된 멤버 조회하기
+    @Query("SELECT m FROM Member m WHERE m.register.approved = true")
+    Page<Member> findAllMemberApproved(Pageable pageable);
+
+    // 미승인 멤버 조회하기
+    @Query("SELECT m FROM Member m WHERE m.register.approved = false")
+    Page<Member> findAllMemberNotApproved(Pageable pageable);
+
+
 }

--- a/src/main/java/com/gdg/homepage/landing/member/service/EmailService.java
+++ b/src/main/java/com/gdg/homepage/landing/member/service/EmailService.java
@@ -1,0 +1,16 @@
+package com.gdg.homepage.landing.member.service;
+
+public interface EmailService {
+    /*
+        회원가입 할 때, 인증 서비스
+        비밀번호 변경 서비스
+     */
+
+
+    // 이메일 발송하기
+    void sendEmailVerification(String email);
+
+    // 코드 검증하기
+    boolean verifyEmail(String email, String code);
+
+}

--- a/src/main/java/com/gdg/homepage/landing/member/service/EmailServiceImpl.java
+++ b/src/main/java/com/gdg/homepage/landing/member/service/EmailServiceImpl.java
@@ -1,0 +1,20 @@
+package com.gdg.homepage.landing.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class EmailServiceImpl implements EmailService {
+
+    @Override
+    public void sendEmailVerification(String email) {
+    }
+
+    @Override
+    public boolean verifyEmail(String email, String code) {
+        return false;
+    }
+}

--- a/src/main/java/com/gdg/homepage/landing/member/service/MemberDetailsService.java
+++ b/src/main/java/com/gdg/homepage/landing/member/service/MemberDetailsService.java
@@ -1,0 +1,34 @@
+package com.gdg.homepage.landing.member.service;
+
+import com.gdg.homepage.landing.member.domain.Member;
+import com.gdg.homepage.landing.member.dto.CustomUserDetails;
+import com.gdg.homepage.landing.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberDetailsService implements UserDetailsService {
+
+    /*
+        시큐리티 관련한 서비스 계층
+     */
+
+    private final MemberRepository repository;
+
+    /// 시큐리티 관련 서비스
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+
+        Member member = repository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("이메일에 해당하는 유저가 존재하지 않습니다."));
+
+        return new CustomUserDetails(member);
+    }
+
+}

--- a/src/main/java/com/gdg/homepage/landing/member/service/MemberService.java
+++ b/src/main/java/com/gdg/homepage/landing/member/service/MemberService.java
@@ -1,7 +1,8 @@
 package com.gdg.homepage.landing.member.service;
 
-import com.gdg.homepage.landing.admin.dto.MemberDetailResponse;
 import com.gdg.homepage.landing.member.domain.Member;
+import com.gdg.homepage.landing.member.dto.MemberLoginRequest;
+import com.gdg.homepage.landing.member.dto.MemberLoginResponse;
 import com.gdg.homepage.landing.member.dto.MemberRegisterRequest;
 import com.gdg.homepage.landing.member.dto.MemberRegisterResponse;
 import com.gdg.homepage.landing.register.api.dto.RegisterRequest;
@@ -16,6 +17,9 @@ public interface MemberService {
 
     // 회원가입
     MemberRegisterResponse registerMember(MemberRegisterRequest request, RegisterRequest registerRequest);
+
+    // 로그인
+    MemberLoginResponse login(MemberLoginRequest request);
 
     // 내 정보 조회하기
     Member loadMyMember(Long memberId);

--- a/src/main/java/com/gdg/homepage/landing/member/service/MemberService.java
+++ b/src/main/java/com/gdg/homepage/landing/member/service/MemberService.java
@@ -1,4 +1,30 @@
 package com.gdg.homepage.landing.member.service;
 
+import com.gdg.homepage.landing.admin.dto.MemberDetailResponse;
+import com.gdg.homepage.landing.member.domain.Member;
+import com.gdg.homepage.landing.member.dto.MemberRegisterRequest;
+import com.gdg.homepage.landing.member.dto.MemberRegisterResponse;
+import com.gdg.homepage.landing.register.api.dto.RegisterRequest;
+
 public interface MemberService {
+
+    /*
+        회원가입
+        로그인 -> JWT 기반 로그인
+        시큐리티 기반의 역할별 접속
+     */
+
+    // 회원가입
+    MemberRegisterResponse registerMember(MemberRegisterRequest request, RegisterRequest registerRequest);
+
+    // 내 정보 조회하기
+    Member loadMyMember(Long memberId);
+
+    // 비밀번호 변경요청하기
+    void requestPasswordChange(Long memberId);
+
+    // 비밀번호 변경하기
+    void changePassword(Long memberId, String newPassword, String confirmPassword);
+
+
 }

--- a/src/main/java/com/gdg/homepage/landing/member/service/MemberService.java
+++ b/src/main/java/com/gdg/homepage/landing/member/service/MemberService.java
@@ -21,6 +21,9 @@ public interface MemberService {
     // 로그인
     MemberLoginResponse login(MemberLoginRequest request);
 
+    // 로그아웃
+    void logout();
+
     // 내 정보 조회하기
     MemberDetailResponse loadMyMember(Long memberId);
 

--- a/src/main/java/com/gdg/homepage/landing/member/service/MemberService.java
+++ b/src/main/java/com/gdg/homepage/landing/member/service/MemberService.java
@@ -1,6 +1,6 @@
 package com.gdg.homepage.landing.member.service;
 
-import com.gdg.homepage.landing.member.domain.Member;
+import com.gdg.homepage.landing.admin.dto.MemberDetailResponse;
 import com.gdg.homepage.landing.member.dto.MemberLoginRequest;
 import com.gdg.homepage.landing.member.dto.MemberLoginResponse;
 import com.gdg.homepage.landing.member.dto.MemberRegisterRequest;
@@ -22,7 +22,7 @@ public interface MemberService {
     MemberLoginResponse login(MemberLoginRequest request);
 
     // 내 정보 조회하기
-    Member loadMyMember(Long memberId);
+    MemberDetailResponse loadMyMember(Long memberId);
 
     // 비밀번호 변경요청하기
     void requestPasswordChange(Long memberId);

--- a/src/main/java/com/gdg/homepage/landing/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/gdg/homepage/landing/member/service/MemberServiceImpl.java
@@ -1,4 +1,74 @@
 package com.gdg.homepage.landing.member.service;
 
+import com.gdg.homepage.landing.admin.dto.MemberDetailResponse;
+import com.gdg.homepage.landing.member.domain.Member;
+import com.gdg.homepage.landing.member.dto.MemberRegisterRequest;
+import com.gdg.homepage.landing.member.dto.MemberRegisterResponse;
+import com.gdg.homepage.landing.member.repository.MemberRepository;
+import com.gdg.homepage.landing.register.api.dto.RegisterRequest;
+import com.gdg.homepage.landing.register.domain.Register;
+import com.gdg.homepage.landing.register.service.RegisterService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository repository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    private final RegisterService registerService;
+    private final EmailService emailService;
+
+    /// 비즈니스 로직 처리
+    @Override
+    public MemberRegisterResponse registerMember(MemberRegisterRequest request, RegisterRequest registerRequest) {
+
+        /// 이메일이 중복되었는지 확인
+        if (repository.existsByEmail(request.getEmail())) {
+            throw new DataIntegrityViolationException("이미 존재하는 이메일입니다.");
+        }
+
+        /// 신청서 작업까지 마무리 되었는지 확인
+        Register register = registerService.createRegister(registerRequest);
+
+        /// 신청서도 작업이 완료되었다면, 신청서와 멤버를 함께 저장
+        Member member = Member.of(request.getEmail(), bCryptPasswordEncoder.encode(request.getPassword()), request.getName(), request.getPhoneNumber(), register);
+
+        return MemberRegisterResponse.from(repository.save(member));
+    }
+
+    @Override
+    public Member loadMyMember(Long memberId) {
+        return repository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("해당하는 멤버가 존재하지 않습니다."));
+    }
+
+    @Override
+    public void requestPasswordChange(Long memberId) {
+        Member member = repository.findById(memberId).orElseThrow(() -> new EntityNotFoundException("해당 멤버가 존재하지 않습니다."));
+        String email = member.getEmail();
+
+        emailService.sendEmailVerification(email);
+    }
+
+    @Override
+    public void changePassword(Long memberId, String newPassword, String confirmPassword) {
+        Member member = repository.findById(memberId).orElseThrow(() -> new EntityNotFoundException("해당 멤버가 존재하지 않습니다."));
+
+        if (!bCryptPasswordEncoder.matches(newPassword, member.getPassword())) {
+            throw new IllegalStateException("설정한 비밀번호가 서로 다릅니다.");
+        }
+
+        member.changePassword(bCryptPasswordEncoder.encode(newPassword));
+    }
+
+
 }
+

--- a/src/main/java/com/gdg/homepage/landing/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/gdg/homepage/landing/member/service/MemberServiceImpl.java
@@ -73,6 +73,24 @@ public class MemberServiceImpl implements MemberService {
         return MemberLoginResponse.from(member.getEmail(), token);
     }
 
+    @Override
+    public void logout() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null && authentication.getPrincipal() instanceof CustomUserDetails) {
+            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+            Long userId = userDetails.getId(); // 현재 사용자 ID 가져오기
+
+            // 현재 인증된 사용자 정보 삭제
+            SecurityContextHolder.clearContext();
+
+            log.info("✅ 로그아웃 완료 - userId: {}", userId);
+        } else {
+            log.warn("⚠️ 로그아웃 실패: 인증 정보 없음");
+        }
+    }
+
+
 
     @Override
     public MemberDetailResponse loadMyMember(Long memberId) {

--- a/src/main/java/com/gdg/homepage/landing/register/api/RegisterController.java
+++ b/src/main/java/com/gdg/homepage/landing/register/api/RegisterController.java
@@ -1,8 +1,7 @@
-package com.gdg.homepage.landing.register.controller;
+package com.gdg.homepage.landing.register.api;
 
 
 import com.gdg.homepage.landing.register.domain.Register;
-import com.gdg.homepage.landing.register.service.RegisterService;
 import com.gdg.homepage.landing.register.service.RegisterServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -11,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/registers")
 @RequiredArgsConstructor
-public class RegisterApi {
+public class RegisterController {
     private final RegisterServiceImpl registerServiceImpl;
 
     @PostMapping

--- a/src/main/java/com/gdg/homepage/landing/register/api/dto/RegisterRequest.java
+++ b/src/main/java/com/gdg/homepage/landing/register/api/dto/RegisterRequest.java
@@ -1,0 +1,23 @@
+package com.gdg.homepage.landing.register.api.dto;
+
+import com.gdg.homepage.landing.register.domain.Role;
+import com.gdg.homepage.landing.register.domain.TechField;
+import com.gdg.homepage.landing.register.domain.TechStack;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class RegisterRequest {
+
+    private Role role;
+    private int grade;
+    private String studentId;
+    private String major;
+
+    private TechField techField;
+    private TechStack techStack;
+
+
+
+}

--- a/src/main/java/com/gdg/homepage/landing/register/api/dto/request.java
+++ b/src/main/java/com/gdg/homepage/landing/register/api/dto/request.java
@@ -1,0 +1,4 @@
+package com.gdg.homepage.landing.register.api.dto;
+
+public class request {
+}

--- a/src/main/java/com/gdg/homepage/landing/register/api/dto/response.java
+++ b/src/main/java/com/gdg/homepage/landing/register/api/dto/response.java
@@ -1,0 +1,4 @@
+package com.gdg.homepage.landing.register.api.dto;
+
+public class response {
+}

--- a/src/main/java/com/gdg/homepage/landing/register/controller/RegisterApi.java
+++ b/src/main/java/com/gdg/homepage/landing/register/controller/RegisterApi.java
@@ -1,4 +1,28 @@
 package com.gdg.homepage.landing.register.controller;
 
+
+import com.gdg.homepage.landing.register.domain.Register;
+import com.gdg.homepage.landing.register.service.RegisterService;
+import com.gdg.homepage.landing.register.service.RegisterServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/registers")
+@RequiredArgsConstructor
 public class RegisterApi {
+    private final RegisterServiceImpl registerServiceImpl;
+
+    @PostMapping
+    public ResponseEntity<Register> createRegister(@RequestBody Register register) {
+        return ResponseEntity.ok(registerServiceImpl.CreateRegister(register));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Register> deleteRegister(@PathVariable Long id) {
+        registerServiceImpl.deleteRegister(id);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/gdg/homepage/landing/register/domain/Register.java
+++ b/src/main/java/com/gdg/homepage/landing/register/domain/Register.java
@@ -21,6 +21,10 @@ public class Register extends BaseTimeEntity {
     @JoinColumn(name = "period_id")
     private JoinPeriod period;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role registeredRole;
+
     @Embedded
     private RegisterSnippet snippet;
 

--- a/src/main/java/com/gdg/homepage/landing/register/domain/Register.java
+++ b/src/main/java/com/gdg/homepage/landing/register/domain/Register.java
@@ -4,16 +4,24 @@ import com.gdg.homepage.common.domain.BaseTimeEntity;
 import com.gdg.homepage.landing.admin.domain.JoinPeriod;
 import com.gdg.homepage.landing.member.domain.Member;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 
 @Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
 public class Register extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
@@ -29,5 +37,23 @@ public class Register extends BaseTimeEntity {
     private RegisterSnippet snippet;
 
     private boolean approved = false;
+
+
+    // 생성자
+    public static Register of(JoinPeriod period, RegisterSnippet snippet ,Role registeredRole) {
+        return Register.builder()
+                .period(period)
+                .snippet(snippet)
+                .registeredRole(registeredRole)
+                .build();
+    }
+
+    public void setMember(Member member) {
+        this.member = member;
+    }
+
+    public void approve() {
+        this.approved = true;
+    }
 
 }

--- a/src/main/java/com/gdg/homepage/landing/register/domain/RegisterSnippet.java
+++ b/src/main/java/com/gdg/homepage/landing/register/domain/RegisterSnippet.java
@@ -2,16 +2,16 @@ package com.gdg.homepage.landing.register.domain;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 @Getter
 public class RegisterSnippet {
-
-    private String name;
-    private String email;
-    private String phoneNumber;
 
     private int grade;
     private String studentId;
@@ -25,5 +25,14 @@ public class RegisterSnippet {
     @Column(nullable = false)
     private TechStack techStack;
 
-
+    // of() 메서드 대신 빌더 패턴으로 객체 생성
+    public static RegisterSnippet of(int grade, String studentId, String major, TechField techField, TechStack techStack) {
+        return RegisterSnippet.builder()
+                .grade(grade)
+                .studentId(studentId)
+                .major(major)
+                .techField(techField)
+                .techStack(techStack)
+                .build();
+    }
 }

--- a/src/main/java/com/gdg/homepage/landing/register/domain/Role.java
+++ b/src/main/java/com/gdg/homepage/landing/register/domain/Role.java
@@ -1,0 +1,5 @@
+package com.gdg.homepage.landing.register.domain;
+
+public enum Role {
+    ORGANIZER, TEAM_MEMBER, MEMBER, NON_MEMBER
+}

--- a/src/main/java/com/gdg/homepage/landing/register/domain/Role.java
+++ b/src/main/java/com/gdg/homepage/landing/register/domain/Role.java
@@ -1,5 +1,19 @@
 package com.gdg.homepage.landing.register.domain;
 
+import com.gdg.homepage.landing.member.domain.MemberRole;
+
 public enum Role {
-    ORGANIZER, TEAM_MEMBER, MEMBER, NON_MEMBER
+    ORGANIZER, TEAM_MEMBER, MEMBER;
+
+    public MemberRole toMemberRole() {
+        if (this == MEMBER) {
+            return MemberRole.NON_MEMBER;
+        } else if (this == TEAM_MEMBER) {
+            return MemberRole.TEAM_MEMBER;
+        } else if (this == ORGANIZER) {
+            return MemberRole.ORGANIZER;
+        }
+        throw new IllegalArgumentException("해당하는 MemberRole이 없습니다: " + this);
+    }
 }
+

--- a/src/main/java/com/gdg/homepage/landing/register/repository/RegisterRepository.java
+++ b/src/main/java/com/gdg/homepage/landing/register/repository/RegisterRepository.java
@@ -2,6 +2,8 @@ package com.gdg.homepage.landing.register.repository;
 
 import com.gdg.homepage.landing.register.domain.Register;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface RegisterRepository extends JpaRepository<Register, Long> {
 }

--- a/src/main/java/com/gdg/homepage/landing/register/service/RegisterService.java
+++ b/src/main/java/com/gdg/homepage/landing/register/service/RegisterService.java
@@ -1,4 +1,14 @@
 package com.gdg.homepage.landing.register.service;
 
+import com.gdg.homepage.landing.register.api.dto.RegisterRequest;
+import com.gdg.homepage.landing.register.domain.Register;
+
 public interface RegisterService {
+
+    /// 회원 생성과 함께 사용할 내부 메서드
+    Register createRegister(RegisterRequest request);
+
+    void deleteRegister(Long id);
+
+
 }

--- a/src/main/java/com/gdg/homepage/landing/register/service/RegisterServiceImpl.java
+++ b/src/main/java/com/gdg/homepage/landing/register/service/RegisterServiceImpl.java
@@ -1,24 +1,36 @@
 package com.gdg.homepage.landing.register.service;
 
+import com.gdg.homepage.landing.admin.domain.JoinPeriod;
+import com.gdg.homepage.landing.admin.service.AdminService;
+import com.gdg.homepage.landing.register.api.dto.RegisterRequest;
 import com.gdg.homepage.landing.register.domain.Register;
+import com.gdg.homepage.landing.register.domain.RegisterSnippet;
 import com.gdg.homepage.landing.register.repository.RegisterRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class RegisterServiceImpl implements RegisterService {
 
-//    @Autowired
-//    public RegisterServiceImpl(RegisterRepository registerRepository) {
-//        this.registerRepository = registerRepository;
-//    }
-
     private final RegisterRepository registerRepository;
-
+    private final AdminService adminService;
 
     public Register CreateRegister(Register register) {
+        return registerRepository.save(register);
+    }
+
+    @Override
+    public Register createRegister(RegisterRequest request) {
+        LocalDateTime now = LocalDateTime.now();
+        JoinPeriod period = adminService.checkJoinPeriod(now);
+
+        RegisterSnippet snippet = RegisterSnippet.of(request.getGrade(), request.getStudentId(), request.getMajor(), request.getTechField(), request.getTechStack());
+        Register register = Register.of(period, snippet, request.getRole());
         return registerRepository.save(register);
     }
 

--- a/src/main/java/com/gdg/homepage/landing/register/service/RegisterServiceImpl.java
+++ b/src/main/java/com/gdg/homepage/landing/register/service/RegisterServiceImpl.java
@@ -1,15 +1,13 @@
 package com.gdg.homepage.landing.register.service;
 
-import com.gdg.homepage.landing.admin.domain.JoinPeriod;
 import com.gdg.homepage.landing.register.domain.Register;
 import com.gdg.homepage.landing.register.repository.RegisterRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import java.util.List;
 
 @Service
-@RequiredArgsConstructor(onConstructor_ = {@Autowired})
+@RequiredArgsConstructor
 public class RegisterServiceImpl implements RegisterService {
 
 //    @Autowired
@@ -20,12 +18,12 @@ public class RegisterServiceImpl implements RegisterService {
     private final RegisterRepository registerRepository;
 
 
-    public Register CreateRegister() {
-        return registerRepository.save(new Register());
+    public Register CreateRegister(Register register) {
+        return registerRepository.save(register);
     }
 
-    public void deleteRegister(Register register) {
-        registerRepository.delete(register);
+    public void deleteRegister(Long id){
+        registerRepository.deleteById(id);
     }
 
 //    public List<Register> getRegisterByJoinPeriod(JoinPeriod joinPeriod) {

--- a/src/main/java/com/gdg/homepage/landing/register/service/RegisterServiceImpl.java
+++ b/src/main/java/com/gdg/homepage/landing/register/service/RegisterServiceImpl.java
@@ -1,4 +1,36 @@
 package com.gdg.homepage.landing.register.service;
 
+import com.gdg.homepage.landing.admin.domain.JoinPeriod;
+import com.gdg.homepage.landing.register.domain.Register;
+import com.gdg.homepage.landing.register.repository.RegisterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor(onConstructor_ = {@Autowired})
 public class RegisterServiceImpl implements RegisterService {
+
+//    @Autowired
+//    public RegisterServiceImpl(RegisterRepository registerRepository) {
+//        this.registerRepository = registerRepository;
+//    }
+
+    private final RegisterRepository registerRepository;
+
+
+    public Register CreateRegister() {
+        return registerRepository.save(new Register());
+    }
+
+    public void deleteRegister(Register register) {
+        registerRepository.delete(register);
+    }
+
+//    public List<Register> getRegisterByJoinPeriod(JoinPeriod joinPeriod) {
+//        return registerRepository.findById(joinPeriod);
+//    }
+
+
 }


### PR DESCRIPTION
### PR 제목
신청서와 회원가입 동시 처리 구현
스프링시큐리티 구현

### PR 내용
- 회원가입과 신청서를 별도로 처리할 경우, 신청서를 작성하지 않았음에도 회원가입만 진행되는 불상사가 발생할 수 있음.
- 이를 방지하기 위해, 회원가입과 신청서를 동시에 처리하는 트랜잭션 처리 필요.
- 유저의 역할에 따른 접속제한 기능 구현
- 로그아웃 API 구현
 
### PR 세부 내용
- **회원가입과 신청서 처리의 동시성 보장**: 회원가입 과정과 신청서 작성 과정이 함께 처리되도록 트랜잭션을 사용하여 일관성 있게 처리합니다.
- **트랜잭션 관리**: 두 작업이 모두 성공적으로 완료될 때만 데이터베이스에 반영되도록 트랜잭션을 설정합니다. 하나라도 실패할 경우 전체 작업이 롤백됩니다.

#### Register에서의 변경점
- **Register와 Member의 일관성**: `Register`와 `Member`를 생성할 때, 둘의 관계를 하나의 트랜잭션으로 묶어 관리합니다. 만약 `Register` 생성이 실패하면 `Member`는 생성되지 않도록 처리합니다.
- **Register 저장 시 트랜잭션 적용**: `Register` 객체가 정상적으로 생성되고 승인된 후에 `Member` 객체가 생성되도록 트랜잭션 처리를 추가합니다.

#### Admin에서의 변경점
- **JoinPeriod와의 관계 처리**: `JoinPeriod`가 존재할 때, 가입하도록 AdminService 수정
- ** MemberAdminService 추가** : Admin 기능 구현

## 예외처리 통과
- 동일한 이메일가입 불가 
- 가입기간이 아닐 경우, 가입 불가
- 멤버는 타 멤버의 권한 수정할 수 없음