### PR TITLE
🔥 fix : 어드민 관련 기능 변경

### DIFF
--- a/src/main/java/com/gdg/homepage/common/config/SecurityConfig.java
+++ b/src/main/java/com/gdg/homepage/common/config/SecurityConfig.java
@@ -30,7 +30,8 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
-                .cors(cors->{})
+                .cors(cors -> {
+                })
                 .authorizeHttpRequests(auth -> auth
                         // Swagger 및 에러 접근 허용
                         .requestMatchers(
@@ -45,7 +46,7 @@ public class SecurityConfig {
 
                         // 기존 설정 유지
                         .requestMatchers("/", "/pageView/increment", "/api/v1/member/register", "/api/v1/member/login", "/api/v1/member/email", "/api/v1/member/email/verify").permitAll()
-                        .requestMatchers("/api/v1/register/**").permitAll()
+                        .requestMatchers("/api/v1/register/**", "/admin/faq/all").permitAll()
                         .requestMatchers("/api/v1/member/**").hasAnyAuthority(
                                 MemberRole.MEMBER.getRole(), MemberRole.NON_MEMBER.getRole(),
                                 MemberRole.TEAM_MEMBER.getRole(), MemberRole.ORGANIZER.getRole())

--- a/src/main/java/com/gdg/homepage/common/domain/StatisticsProjection.java
+++ b/src/main/java/com/gdg/homepage/common/domain/StatisticsProjection.java
@@ -1,9 +1,9 @@
 package com.gdg.homepage.common.domain;
 
 public interface StatisticsProjection {
-    int getCurrent();   // 기준일 이후 수치
-    Integer getPrevious();  // 기준일 이전 수치
     Integer getTotal();
+    Integer getCurrent();   // 기준일 이후 수치
+    Integer getPrevious();  // 기준일 이전 수치
 
     // "증가량": 현재 기간 동안 새로 늘어난 값
     default Integer increase() {
@@ -11,7 +11,7 @@ public interface StatisticsProjection {
     }
 
     // "총합"
-    default int total() {
+    default Integer total() {
         return getTotal();
     }
 

--- a/src/main/java/com/gdg/homepage/landing/admin/controller/MemberAdminApi.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/controller/MemberAdminApi.java
@@ -3,7 +3,7 @@ package com.gdg.homepage.landing.admin.controller;
 import com.gdg.homepage.common.response.ApiResponse;
 import com.gdg.homepage.common.response.page.PageRequest;
 import com.gdg.homepage.common.response.page.PageResponse;
-import com.gdg.homepage.landing.admin.dto.MemberApproveRequest;
+import com.gdg.homepage.landing.admin.dto.MemberApprovalDecisionRequest;
 import com.gdg.homepage.landing.admin.dto.MemberDetailResponse;
 import com.gdg.homepage.landing.admin.dto.MemberListResponse;
 import com.gdg.homepage.landing.admin.dto.MemberUpgradeRequest;
@@ -59,9 +59,20 @@ public class MemberAdminApi {
             description = "관리자가 멤버를 승인합니다."
     )
     @PutMapping("/approve")
-    public ApiResponse<String> approveRole(@AuthenticationPrincipal CustomUserDetails memberDetails, @RequestBody @Valid MemberApproveRequest request){
+    public ApiResponse<String> approveRole(@AuthenticationPrincipal CustomUserDetails memberDetails, @RequestBody @Valid MemberApprovalDecisionRequest request){
         request.setAdminId(memberDetails.getId());
         adminService.approveMember(request);
+        return ApiResponse.created("승인 되었습니다.");
+    }
+
+    @Operation(
+            summary = "멤버 거절",
+            description = "관리자가 멤버를 거절하고 DB에서 삭제합니다."
+    )
+    @PutMapping("/reject")
+    public ApiResponse<String> rejectRole(@AuthenticationPrincipal CustomUserDetails memberDetails, @RequestBody @Valid MemberApprovalDecisionRequest request){
+        request.setAdminId(memberDetails.getId());
+        adminService.rejectMember(request);
         return ApiResponse.created("승인 되었습니다.");
     }
 

--- a/src/main/java/com/gdg/homepage/landing/admin/controller/MemberAdminApi.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/controller/MemberAdminApi.java
@@ -73,7 +73,7 @@ public class MemberAdminApi {
     public ApiResponse<String> rejectRole(@AuthenticationPrincipal CustomUserDetails memberDetails, @RequestBody @Valid MemberApprovalDecisionRequest request){
         request.setAdminId(memberDetails.getId());
         adminService.rejectMember(request);
-        return ApiResponse.created("승인 되었습니다.");
+        return ApiResponse.created("거절 되었습니다.");
     }
 
     @Operation(

--- a/src/main/java/com/gdg/homepage/landing/admin/dto/MemberApprovalDecisionRequest.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/dto/MemberApprovalDecisionRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
-public class MemberApproveRequest {
+public class MemberApprovalDecisionRequest {
 
     private Long adminId;
 

--- a/src/main/java/com/gdg/homepage/landing/admin/dto/MemberDetailResponse.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/dto/MemberDetailResponse.java
@@ -31,6 +31,7 @@ public class MemberDetailResponse {
                 .major(snippet.getMajor())
                 .field(snippet.getTechField())
                 .stack(snippet.getTechStack())
+                .approvedAt(member.getRegister().getApprovedAt())
                 .build();
 
     }

--- a/src/main/java/com/gdg/homepage/landing/admin/dto/MemberDetailResponse.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/dto/MemberDetailResponse.java
@@ -2,8 +2,13 @@ package com.gdg.homepage.landing.admin.dto;
 
 import com.gdg.homepage.landing.member.domain.Member;
 import com.gdg.homepage.landing.register.domain.RegisterSnippet;
+import com.gdg.homepage.landing.register.domain.TechField;
+import com.gdg.homepage.landing.register.domain.TechStack;
 import lombok.Builder;
 import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @Builder
@@ -13,8 +18,9 @@ public class MemberDetailResponse {
     private MemberListResponse member;
     private String major;
 
-    private String field;
-    private String stack;
+    private List<TechField> field;
+    private List<TechStack> stack;
+    private LocalDateTime approvedAt;
 
     public static MemberDetailResponse from(Member member) {
 
@@ -23,8 +29,8 @@ public class MemberDetailResponse {
         return MemberDetailResponse.builder()
                 .member(MemberListResponse.from(member))
                 .major(snippet.getMajor())
-                .field(String.valueOf(snippet.getTechField()))
-                .stack(String.valueOf(snippet.getTechStack()))
+                .field(snippet.getTechField())
+                .stack(snippet.getTechStack())
                 .build();
 
     }

--- a/src/main/java/com/gdg/homepage/landing/admin/dto/MemberListResponse.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/dto/MemberListResponse.java
@@ -15,10 +15,10 @@ public class MemberListResponse {
     private Long memberId;
     private String email;
     private String name;
-    private String grade;
+    private int grade;
     private String studentId;
     private String phoneNumber;
-    private String role;
+    private MemberRole role;
     private boolean approved;
 
     // from
@@ -26,23 +26,23 @@ public class MemberListResponse {
 
         RegisterSnippet snippet = member.getRegister().getSnippet();
 
-        String role = String.valueOf(member.getRole());
+        MemberRole role = member.getRole();
 
         if (member.getRole().equals(MemberRole.NON_MEMBER)){
-            role = String.valueOf(member.getRegister().getRegisteredRole());
+            role = member.getRegister().getRegisteredRole().toMemberRole();
         }
+
         return MemberListResponse.builder()
                 .memberId(member.getId())
                 .email(member.getEmail())
                 .name(member.getName())
-                .grade(String.valueOf(snippet.getGrade()))
+                .grade(snippet.getGrade().getValue())
                 .studentId(snippet.getStudentId())
                 .phoneNumber(member.getPhoneNumber())
                 .role(role)
                 .approved(member.getRegister().isApproved())
                 .build();
     }
-
     // from
     public static List<MemberListResponse> from(List<Member> members) {
 

--- a/src/main/java/com/gdg/homepage/landing/admin/dto/MemberListResponse.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/dto/MemberListResponse.java
@@ -6,6 +6,7 @@ import com.gdg.homepage.landing.register.domain.RegisterSnippet;
 import lombok.Builder;
 import lombok.Data;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
@@ -20,6 +21,7 @@ public class MemberListResponse {
     private String phoneNumber;
     private MemberRole role;
     private boolean approved;
+    private LocalDateTime approvedAt;
 
     // from
     public static MemberListResponse from(Member member) {
@@ -41,6 +43,7 @@ public class MemberListResponse {
                 .phoneNumber(member.getPhoneNumber())
                 .role(role)
                 .approved(member.getRegister().isApproved())
+                .approvedAt(member.getRegister().getApprovedAt())
                 .build();
     }
     // from

--- a/src/main/java/com/gdg/homepage/landing/admin/repository/PageViewRepository.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/repository/PageViewRepository.java
@@ -13,11 +13,13 @@ public interface PageViewRepository extends JpaRepository<PageView, Long> {
     Long getPageViewCount();
 
     @Query("""
-SELECT 
-    COUNT(p) as total,
-    COUNT(CASE WHEN p.createdAt >= :startDate THEN 1 END) as current,
-    COUNT(CASE WHEN p.createdAt < :startDate THEN 1 END) as previous
+
+            SELECT 
+    COALESCE(SUM(p.viewCount), 0) AS total,
+    COALESCE(SUM(CASE WHEN p.createdAt >= :startDate THEN p.viewCount ELSE 0 END), 0) AS current,
+    COALESCE(SUM(CASE WHEN p.createdAt < :startDate THEN p.viewCount ELSE 0 END), 0) AS previous
 FROM PageView p
 """)
     StatisticsProjection getPageViewStatistics(@Param("startDate") LocalDateTime startOfPeriod);
+
 }

--- a/src/main/java/com/gdg/homepage/landing/admin/service/MemberAdminService.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/service/MemberAdminService.java
@@ -3,7 +3,7 @@ package com.gdg.homepage.landing.admin.service;
 
 import com.gdg.homepage.common.response.page.PageRequest;
 import com.gdg.homepage.common.response.page.PageResponse;
-import com.gdg.homepage.landing.admin.dto.MemberApproveRequest;
+import com.gdg.homepage.landing.admin.dto.MemberApprovalDecisionRequest;
 import com.gdg.homepage.landing.admin.dto.MemberDetailResponse;
 import com.gdg.homepage.landing.admin.dto.MemberListResponse;
 import com.gdg.homepage.landing.admin.dto.MemberUpgradeRequest;
@@ -35,7 +35,9 @@ public interface MemberAdminService {
     int getTotalMembers();
 
     // 승인하기
-    void approveMember(MemberApproveRequest request);
+    void approveMember(MemberApprovalDecisionRequest request);
+
+    void rejectMember(MemberApprovalDecisionRequest request);
 
     // 회원 탈퇴 시키기
     void removeMember(Long memberId);

--- a/src/main/java/com/gdg/homepage/landing/admin/service/MemberAdminServiceImpl.java
+++ b/src/main/java/com/gdg/homepage/landing/admin/service/MemberAdminServiceImpl.java
@@ -2,12 +2,13 @@ package com.gdg.homepage.landing.admin.service;
 
 import com.gdg.homepage.common.response.page.PageRequest;
 import com.gdg.homepage.common.response.page.PageResponse;
-import com.gdg.homepage.landing.admin.dto.MemberApproveRequest;
+import com.gdg.homepage.landing.admin.dto.MemberApprovalDecisionRequest;
 import com.gdg.homepage.landing.member.domain.Member;
 import com.gdg.homepage.landing.admin.dto.MemberDetailResponse;
 import com.gdg.homepage.landing.admin.dto.MemberListResponse;
 import com.gdg.homepage.landing.admin.dto.MemberUpgradeRequest;
 import com.gdg.homepage.landing.member.repository.MemberRepository;
+import com.gdg.homepage.landing.register.repository.RegisterRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -24,6 +25,7 @@ import java.util.List;
 public class MemberAdminServiceImpl implements MemberAdminService {
 
     private final MemberRepository repository;
+    private final RegisterRepository registerRepository;
 
     @Override
     public PageResponse<MemberListResponse> findAll(PageRequest pageRequest) {
@@ -81,7 +83,7 @@ public class MemberAdminServiceImpl implements MemberAdminService {
     }
 
     @Override
-    public void approveMember(MemberApproveRequest request) {
+    public void approveMember(MemberApprovalDecisionRequest request) {
         Member admin = repository.findById(request.getAdminId())
                 .orElseThrow(() -> new EntityNotFoundException("해당하는 어드민이 존재하지 않습니다."));
 
@@ -93,6 +95,24 @@ public class MemberAdminServiceImpl implements MemberAdminService {
 
         // 역할 변경
         member.changeRole(admin, member);
+    }
+
+    @Override
+    public void rejectMember(MemberApprovalDecisionRequest request) {
+
+        Member admin = repository.findById(request.getAdminId())
+                .orElseThrow(() -> new EntityNotFoundException("해당하는 어드민이 존재하지 않습니다."));
+
+        Member member = repository.findById(request.getUserId())
+                .orElseThrow(() -> new EntityNotFoundException("승인할 멤버가 존재하지 않습니다."));
+
+        // 승인
+        member.getRegister().reject();
+
+        // 삭제 처리 ?
+        repository.delete(member);
+        registerRepository.deleteByMember(member);
+
     }
 
     @Override

--- a/src/main/java/com/gdg/homepage/landing/register/domain/Grade.java
+++ b/src/main/java/com/gdg/homepage/landing/register/domain/Grade.java
@@ -1,5 +1,6 @@
 package com.gdg.homepage.landing.register.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -16,4 +17,8 @@ public enum Grade {
 
     private final int value;
 
+    @JsonIgnore
+    public int getValue() {
+        return value;
+    }
 }

--- a/src/main/java/com/gdg/homepage/landing/register/domain/Register.java
+++ b/src/main/java/com/gdg/homepage/landing/register/domain/Register.java
@@ -10,6 +10,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDateTime;
+
 
 @Entity
 @AllArgsConstructor
@@ -40,6 +42,8 @@ public class Register extends BaseTimeEntity {
 
     private boolean approved = false;
 
+    private LocalDateTime approvedAt;
+
 
     // 생성자
     public static Register of(JoinPeriod period, RegisterSnippet snippet ,Role registeredRole) {
@@ -56,6 +60,7 @@ public class Register extends BaseTimeEntity {
 
     public void approve() {
         this.approved = true;
+        this.approvedAt = LocalDateTime.now();
     }
 
     public void reject() {

--- a/src/main/java/com/gdg/homepage/landing/register/domain/Register.java
+++ b/src/main/java/com/gdg/homepage/landing/register/domain/Register.java
@@ -58,6 +58,10 @@ public class Register extends BaseTimeEntity {
         this.approved = true;
     }
 
+    public void reject() {
+        this.approved = false;
+    }
+
 
     // 수정 필요
     public void updateSnippet(RegisterSnippet snippet) {

--- a/src/main/java/com/gdg/homepage/landing/register/repository/RegisterRepository.java
+++ b/src/main/java/com/gdg/homepage/landing/register/repository/RegisterRepository.java
@@ -1,6 +1,7 @@
 package com.gdg.homepage.landing.register.repository;
 
 import com.gdg.homepage.common.domain.StatisticsProjection;
+import com.gdg.homepage.landing.member.domain.Member;
 import com.gdg.homepage.landing.register.domain.Register;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -28,4 +29,5 @@ public interface RegisterRepository extends JpaRepository<Register, Long> {
         """)
     StatisticsProjection getApplicationStatistics(@Param("startDate") LocalDateTime startOfPeriod);
 
+    void deleteByMember(Member member);
 }


### PR DESCRIPTION
## 📌 요청 사항 
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
### 1. 멤버 관련 API 수정
1-1. grade 필드 값 오류

문제: 멤버 상세 조회, 승인된 멤버 목록 조회, 미승인된 멤버 목록 조회 API에서 grade 필드에 1학년, 2학년 등 학년이 아닌 ORGANIZER 등의 역할이 출력됨.
조치: 해당 API들에서 grade 필드가 실제 학년(1, 2, 3 등) 으로 올바르게 매핑되도록 수정 필요.
1-2. field, stack 필드 형식 수정

문제: 현재 응답 값은 문자열 형식 (예: "REACT, NODE_JS")으로 반환됨.
요구사항: 응답을 배열 형식으로 수정해야 함.
field: ["FRONT_END"]
stack: ["REACT", "NEXT_JS", "NODE_JS", "FLUTTER", "REACT_NATIVE"]
1-3. 가입일 필드 추가

요구사항: 멤버 상세 응답에 가입일(승인 요청 기준) 정보 추가 필요.
### 2. 멤버 승인 거절 API 개발
요구사항: 미승인 멤버를 거절할 수 있는 API 신규 개발 필요.
예상: PATCH /api/members/{memberId}/reject 또는 유사한 방식.
### 3. 페이지 조회 수 증가 관련 이슈
문제: 페이지 조회 수 증가 API는 성공적으로 요청되지만,
분석 페이지 데이터 조회 API의 pageView 값이 변화하지 않음.
조치: 증가 API → DB 반영 → 조회 API까지 값이 제대로 반영되는지 데이터 흐름 확인 및 버그 수정 필요.
### 4. 멤버 권한(role) 명칭 통일
문제:
멤버 권한 수정 API는 ROLE_MEMBER, ROLE_TEAM_MEMBER 등의 Enum 형태 사용.
멤버 상세 조회 API에서는 MEMBER 형식으로 전달됨.
조치: 모든 API에서 일관된 형식(enum full name) 으로 전달되도록 수정 필요.
예: ROLE_MEMBER, ROLE_TEAM_MEMBER, ROLE_ORGANIZER, ROLE_NON_MEMBER
### 5. FAQ 전체 조회 API 비로그인 접근 허용
문제: 현재는 비로그인 시 FAQ 전체 조회 API 호출 시 401 Unauthorized 발생.
조치: 해당 API는 비회원도 접근 가능하도록 인증 로직 수정 필요. (@PermitAll, @AllowAnonymous 등)

## 🔍 해결
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
### 1. 멤버 관련 API 수정
1-1. grade 필드 값 오류
-> 해결 : int형으로 수정
1 - 1학년
2 - 2학년
3 -3학년,
4 - 4학년,
5 - 5학년,
6 - 졸업생,
7 - 운영진전용 계정 생성을 위한 것으로 무시해주시면 됩니다!;
입니다

1-2. field, stack 필드 형식 수정
-> 해결 : 배열으로 응답 

1-3. 가입일 필드 추가
-> 해결 : 승인이 안될때는 null로 해두었습니다

### 2. 멤버 승인 거절 API 개발
-> 해결 : 새로운 API개발.
-> 멤버랑 신청서 자체가, DB에서 삭제됩니다
-> 요구사항에서 멤버와 신청서는 하나로 관리된다고 되어있어서, 거절을 하게되면 신청서와 멤버가 아예 삭제됩니다.
-> 고쳐야한다면 추가적으로 알려주세요!

### 3. 페이지 조회 수 증가 관련 이슈
-> 해결

 ### 4. 멤버 권한(role) 명칭 통일
-> 해결 :ROLE_ 붙인 것으로 통일

###5. FAQ 전체 조회 API 비로그인 접근 허용
-> 해결


## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
